### PR TITLE
Fix an issue with `mc keys` for items without a TTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.1 - ????-??-??
+
+- Fixed an issue where `mc keys` would fail for items without a TTL. #16
+
 ## v0.4.0 - 2023-03-17
 
 - Add the ability to use mTLS connections to Memcached for `mc` and `mtop`. #13

--- a/src/mtop/client/core.rs
+++ b/src/mtop/client/core.rs
@@ -171,8 +171,7 @@ impl Ord for Value {
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct Meta {
     pub key: String,
-    pub expires: u32,
-    pub last_access: u32,
+    pub expires: i64, // Signed because Memcached uses '-1' for keys that don't expire (set with TTL 0)
     pub size: u64,
 }
 
@@ -183,7 +182,6 @@ impl TryFrom<HashMap<String, String>> for Meta {
         Ok(Meta {
             key: parse_field("key", &value)?,
             expires: parse_field("exp", &value)?,
-            last_access: parse_field("la", &value)?,
             size: parse_field("size", &value)?,
         })
     }


### PR DESCRIPTION
Items without a TTL (set with a TTL of 0) caused parsing of results from `lru_crawlwer metadump` to fail. This was due to '-1` being used for the expiration time of items with an infinite TTL (0).