### PR TITLE
Pass raw values to be parsed into a Meta by reference

### DIFF
--- a/src/mtop/client/pool.rs
+++ b/src/mtop/client/pool.rs
@@ -12,6 +12,7 @@ use tokio_rustls::rustls::{Certificate, ClientConfig, OwnedTrustAnchor, PrivateK
 use tokio_rustls::TlsConnector;
 use webpki::TrustAnchor;
 
+#[derive(Debug)]
 pub struct PooledMemcached {
     inner: Memcached,
     host: String,

--- a/src/mtop/queue.rs
+++ b/src/mtop/queue.rs
@@ -37,7 +37,7 @@ impl StatsQueue {
                 // the entire measurement queue, skip this insert instead (less disruptive to users
                 // to miss a measurement than cause the UI to reset).
                 tracing::debug!(
-                    message = "server uptime did not advanced, dropping measurement",
+                    message = "server uptime did not advance, dropping measurement",
                     old_uptime = prev.uptime,
                     current_uptime = m.uptime,
                 );


### PR DESCRIPTION
This allows us to avoid allocating a new HashMap for every key in the cache when running `mc keys`.