### PR TITLE
Don't return early from update on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## unreleased
+
+- Fix a bug where stats for some servers were not updated if another server returned an error. #34
+
 ## v0.5.0 - 2023-04-30
 
 - Minor performance improvement when running `mc keys`. #26


### PR DESCRIPTION
In the stats update loop, log errors instead of returning early so that we get a chance to update status for each of the servers.