### PR TITLE
Spawn a new task to fetch stats from each server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## unreleased
+
+- Fetch stats from each server in `mtop` in parallel. #46
+
 ## v0.6.0 - 2023-07-10
 
 - Add UI to `mtop` for per-slab metrics. #41


### PR DESCRIPTION
Instead of fetching stats from each server in a loop, spawn a new future for each one and await them all at the end of the update task.