### PR TITLE
Add a default 5 second timeout to mtop network operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.7.1 - unreleased
+
+- Add default 5 second timeout to network operations done by `mtop`. #90
+
 ## v0.7.0 - 2023-11-28
 
 - Build binaries for Linux Musl libc target. #83

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,7 @@ dependencies = [
 name = "mtop-client"
 version = "0.7.0"
 dependencies = [
+ "pin-project-lite",
  "rustls-pemfile",
  "rustls-webpki",
  "tokio",

--- a/mtop-client/Cargo.toml
+++ b/mtop-client/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["top", "memcached"]
 edition = "2021"
 
 [dependencies]
+pin-project-lite = "0.2.13"
 rustls-pemfile = "1.0.2"
 rustls-webpki = "0.101.2"
 tokio = { version = "1.14.0", features = ["full"] }

--- a/mtop-client/src/core.rs
+++ b/mtop-client/src/core.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use std::io;
 use std::ops::Deref;
 use std::str::FromStr;
+use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader, BufWriter, Lines};
 
 #[derive(Debug, Default, PartialEq, Clone)]
@@ -526,6 +527,16 @@ impl MtopError {
         MtopError {
             kind: ErrorKind::Configuration,
             repr: ErrorRepr::MessageCause(msg.into(), Box::new(e)),
+        }
+    }
+
+    pub fn timeout<D>(t: Duration, operation: D) -> MtopError
+    where
+        D: fmt::Display,
+    {
+        MtopError {
+            kind: ErrorKind::IO,
+            repr: ErrorRepr::Message(format!("operation {} timed out after {:?}", operation, t)),
         }
     }
 

--- a/mtop-client/src/lib.rs
+++ b/mtop-client/src/lib.rs
@@ -1,8 +1,10 @@
 mod core;
 mod pool;
+mod timeout;
 
 pub use crate::core::{
     ErrorKind, Memcached, Meta, MtopError, ProtocolError, ProtocolErrorKind, Slab, SlabItem, SlabItems, Slabs, Stats,
     Value,
 };
 pub use crate::pool::{MemcachedPool, PoolConfig, PooledMemcached, TLSConfig};
+pub use crate::timeout::{Timed, Timeout};

--- a/mtop-client/src/timeout.rs
+++ b/mtop-client/src/timeout.rs
@@ -1,0 +1,58 @@
+use crate::MtopError;
+use pin_project_lite::pin_project;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+/// `Timeout` can be used to add a timeout to any future emitted by mtop.
+pub trait Timeout: Sized {
+    fn timeout<S>(self, t: Duration, operation: S) -> Timed<Self>
+    where
+        S: Into<String>;
+}
+
+impl<F, V> Timeout for F
+where
+    F: Future<Output = Result<V, MtopError>>,
+{
+    fn timeout<S>(self, t: Duration, operation: S) -> Timed<F>
+    where
+        S: Into<String>,
+    {
+        Timed {
+            operation: operation.into(),
+            time: t,
+            inner: tokio::time::timeout(t, self),
+        }
+    }
+}
+
+pin_project! {
+    #[derive(Debug)]
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct Timed<T> {
+        operation: String,
+        time: Duration,
+        #[pin]
+        inner: tokio::time::Timeout<T>,
+    }
+}
+
+impl<F, V> Future for Timed<F>
+where
+    F: Future<Output = Result<V, MtopError>>,
+{
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        // Poll the inner Timeout future and unwrap one layer of Result it adds,
+        // converting a timeout into specific form of an MtopError
+        this.inner.poll(cx).map(|res| match res {
+            Ok(Ok(v)) => Ok(v),
+            Ok(Err(e)) => Err(e),
+            Err(_e) => Err(MtopError::timeout(*this.time, this.operation)),
+        })
+    }
+}


### PR DESCRIPTION
Add a 5 second timeout to any network operations done by the `mtop` binary such as establishing connections or reading statistics from the server.

Fixes #89