### PR TITLE
Validate keys and add support for add/replace commands

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    # Temporary while https://github.com/rust-lang/rust-clippy/issues/12014 is affecting stable
+    - name: Rustup
+      run: rustup update nightly && rustup default nightly && rustup component add clippy rustfmt
     - name: Versions
       run: cargo --version && rustc --version
     - name: Build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.7.1 - unreleased
 
 - Add default 5 second timeout to network operations done by `mtop`. #90
+- Add `add` and `replace` commands to `mc. #95 
 - TLS related dependency updates. #93
 
 ## v0.7.0 - 2023-11-28


### PR DESCRIPTION
Validate keys for all methods that accept them and add support for the add/replace commands to the client along with corresponding `mc` commands.