### PR TITLE
Use SocketAddr within Server abstraction

### DIFF
--- a/mtop-client/src/core.rs
+++ b/mtop-client/src/core.rs
@@ -1031,7 +1031,7 @@ impl fmt::Debug for Memcached {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 #[repr(transparent)]
 pub struct Key(String);
 

--- a/mtop-client/src/lib.rs
+++ b/mtop-client/src/lib.rs
@@ -8,5 +8,5 @@ pub use crate::core::{
     ErrorKind, Key, Memcached, Meta, MtopError, ProtocolError, ProtocolErrorKind, Slab, SlabItem, SlabItems, Slabs,
     Stats, Value,
 };
-pub use crate::pool::{MemcachedPool, PoolConfig, PooledMemcached, Server, TLSConfig};
+pub use crate::pool::{DiscoveryDefault, MemcachedPool, PoolConfig, PooledMemcached, Server, ServerID, TLSConfig};
 pub use crate::timeout::{Timed, Timeout};

--- a/mtop/src/queue.rs
+++ b/mtop/src/queue.rs
@@ -1,8 +1,25 @@
-use mtop_client::{SlabItems, Slabs, Stats};
+use mtop_client::{ServerID, SlabItems, Slabs, Stats};
 use std::collections::{HashMap, VecDeque};
+use std::fmt;
 use std::sync::Arc;
 use tokio::runtime::Handle;
 use tokio::sync::Mutex;
+
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[repr(transparent)]
+pub struct Host(String);
+
+impl Host {
+    pub fn from(id: ServerID) -> Self {
+        Self(id.to_string())
+    }
+}
+
+impl fmt::Display for Host {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct StatsDelta {
@@ -20,7 +37,7 @@ pub struct ServerStats {
 
 #[derive(Debug)]
 pub struct StatsQueue {
-    queues: Mutex<HashMap<String, VecDeque<ServerStats>>>,
+    queues: Mutex<HashMap<Host, VecDeque<ServerStats>>>,
     max_size: usize,
 }
 
@@ -32,12 +49,9 @@ impl StatsQueue {
         }
     }
 
-    pub async fn insert<H>(&self, host: H, stats: Stats, slabs: Slabs, items: SlabItems)
-    where
-        H: Into<String>,
-    {
+    pub async fn insert(&self, host: Host, stats: Stats, slabs: Slabs, items: SlabItems) {
         let mut map = self.queues.lock().await;
-        let q = map.entry(host.into()).or_insert_with(VecDeque::new);
+        let q = map.entry(host).or_default();
 
         if let Some(prev) = q.back() {
             if stats.uptime == prev.stats.uptime {
@@ -84,12 +98,9 @@ impl StatsQueue {
         }
     }
 
-    pub async fn read_delta<H>(&self, host: H) -> Option<StatsDelta>
-    where
-        H: AsRef<str>,
-    {
+    pub async fn read_delta(&self, host: &Host) -> Option<StatsDelta> {
         let map = self.queues.lock().await;
-        map.get(host.as_ref()).and_then(|q| match (q.front(), q.back()) {
+        map.get(host).and_then(|q| match (q.front(), q.back()) {
             // The delta is only valid if there are more than two entries in the queue. This
             // avoids division by zero errors (since the time for the entries would be the same).
             (Some(previous), Some(current)) if q.len() >= 2 => {
@@ -116,17 +127,11 @@ impl BlockingStatsQueue {
         Self { queue, handle }
     }
 
-    pub fn insert<H>(&self, host: H, stats: Stats, slabs: Slabs, items: SlabItems)
-    where
-        H: Into<String>,
-    {
+    pub fn insert(&self, host: Host, stats: Stats, slabs: Slabs, items: SlabItems) {
         self.handle.block_on(self.queue.insert(host, stats, slabs, items))
     }
 
-    pub fn read_delta<H>(&self, host: H) -> Option<StatsDelta>
-    where
-        H: AsRef<str>,
-    {
+    pub fn read_delta(&self, host: &Host) -> Option<StatsDelta> {
         self.handle.block_on(self.queue.read_delta(host))
     }
 }


### PR DESCRIPTION
Rework the way `Server` in the client works such that it wraps an address and server name instead of a string used for both connection and TLS name resolution. This change also indexes server-specific results (stats, meta, etc.) by ServerID instead of Server. ServerID is an opaque unique ID for a particular server.

Fixes #103