### PR TITLE
Add support for `mc bench` command to benchmark servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## v0.8.0 - unreleased
 
 - Add default 5 second timeout to network operations done by `mtop`. #90
-- Add `incr`, `decr`, `add`, and `replace` commands to `mc`. #95 #98
+- Add default 30 second timeout to network operaitons done by `mc`. #111
+- Add `bench`, `incr`, `decr`, `add`, and `replace` commands to `mc`. #95 #98 #111
 - TLS related dependency updates. #93
 - Create high-level client for operating on multiple servers. #101
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,9 +37,9 @@ checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "anstyle"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+checksum = "2faccea4cc4ab4a667ce676a30e8ec13922a692c99bb8f5b11f1502c72e04220"
 
 [[package]]
 name = "autocfg"
@@ -234,9 +234,9 @@ checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
 name = "itertools"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -252,6 +252,12 @@ name = "libc"
 version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+
+[[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "linux-raw-sys"
@@ -277,9 +283,9 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "lru"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2994eeba8ed550fd9b47a0b38f0242bc3344e496483c6180b69139cc2fa5d1d7"
+checksum = "db2c024b41519440580066ba82aab04092b333e09066a5eb86c7c4890df31f22"
 dependencies = [
  "hashbrown",
 ]
@@ -318,6 +324,8 @@ dependencies = [
  "clap",
  "crossterm",
  "mtop-client",
+ "rand",
+ "rand_distr",
  "ratatui",
  "tokio",
  "tracing",
@@ -346,6 +354,16 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+dependencies = [
+ "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -415,6 +433,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,6 +454,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand",
 ]
 
 [[package]]

--- a/mtop-client/src/client.rs
+++ b/mtop-client/src/client.rs
@@ -397,7 +397,6 @@ impl MemcachedClient {
 
 #[cfg(test)]
 mod test {
-
     // TODO: Actually figure out how to test this without a bunch of boilerplate.
 
     ///////////

--- a/mtop/Cargo.toml
+++ b/mtop/Cargo.toml
@@ -14,6 +14,8 @@ edition = "2021"
 clap = { version = "4.1.8", features = ["cargo", "derive", "help", "error-context", "std", "string", "usage", "wrap_help"], default_features = false }
 crossterm = "0.27.0"
 mtop-client = { path = "../mtop-client", version = "0.7.0" }
+rand = "0.8.5"
+rand_distr = "0.4.3"
 ratatui = "0.25.0"
 tokio = { version = "1.14.0", features = ["full"] }
 tracing = "0.1.11"

--- a/mtop/src/bench.rs
+++ b/mtop/src/bench.rs
@@ -1,0 +1,207 @@
+use mtop_client::{MemcachedClient, MtopError, Timeout};
+use rand::Rng;
+use rand_distr::Exp;
+use std::fmt;
+use std::str::FromStr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::runtime::Handle;
+use tokio::time;
+use tokio::time::Instant;
+
+const MAX_ITEM_SIZE: usize = 64 * 1024;
+const NUM_KEYS: usize = 1000;
+const GET_BATCH_SIZE: usize = 100;
+
+#[derive(Debug, Clone, Copy, PartialOrd, PartialEq)]
+#[repr(transparent)]
+pub struct Percent(f64);
+
+impl Percent {
+    pub fn unchecked(v: f64) -> Self {
+        assert!(v >= 0.0, "percent must be >= 0.0");
+        assert!(v <= 1.0, "percent must be <= 1.0");
+        Self(v)
+    }
+
+    pub fn as_f64(&self) -> f64 {
+        self.0
+    }
+}
+
+impl FromStr for Percent {
+    type Err = MtopError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let v = s
+            .parse()
+            .map_err(|e| MtopError::configuration_cause(format!("invalid percent {}", s), e))?;
+
+        if v < 0.0 || v > 1.0 {
+            Err(MtopError::configuration(format!("invalid percent {}", v)))
+        } else {
+            Ok(Self(v))
+        }
+    }
+}
+
+impl fmt::Display for Percent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[derive(Debug)]
+pub struct Bencher {
+    client: Arc<MemcachedClient>,
+    handle: Handle,
+    delay: Duration,
+    timeout: Duration,
+    ttl: Duration,
+    write_percent: Percent,
+    concurrency: usize,
+}
+
+impl Bencher {
+    pub fn new(
+        client: MemcachedClient,
+        handle: Handle,
+        delay: Duration,
+        timeout: Duration,
+        ttl: Duration,
+        write_percent: Percent,
+        concurrency: usize,
+    ) -> Self {
+        Self {
+            client: Arc::new(client),
+            handle,
+            delay,
+            timeout,
+            ttl,
+            write_percent,
+            concurrency,
+        }
+    }
+    pub async fn run(&self, time: Duration) -> Vec<Summary> {
+        let run = Arc::new(AtomicBool::new(true));
+        let mut tasks = Vec::with_capacity(self.concurrency);
+
+        for worker in 0..self.concurrency {
+            // Copy everything needed for the future so that we don't capture "self".
+            let mut interval = time::interval(self.delay);
+            let run = run.clone();
+            let client = self.client.clone();
+            let write_percent = self.write_percent;
+            let ttl = self.ttl.as_secs() as u32;
+            let timeout = self.timeout;
+
+            tasks.push((worker, self.handle.spawn(async move {
+                let kvs = fixture_data(worker, NUM_KEYS);
+                let mut stats = Summary::default();
+                stats.worker = worker;
+
+                while run.load(Ordering::Acquire) {
+                    let set_start = interval.tick().await;
+
+                    for kv in kvs.iter() {
+                        // Write a small percentage of fixture data because cache workloads skew read heavy.
+                        if rand::thread_rng().gen_bool(write_percent.as_f64()) {
+                            if let Err(e) = client.set(&kv.key, 0, ttl, &kv.val).timeout(timeout, "client.set").await {
+                                tracing::debug!(message = "unable to set item", key = kv.key, payload_size = kv.val.len(), err = %e);
+                            } else {
+                                stats.sets += 1;
+                            }
+                        }
+                    }
+
+                    stats.sets_time += set_start.elapsed();
+                    let get_start = Instant::now();
+
+                    for batch in kvs.chunks(GET_BATCH_SIZE) {
+                        let keys: Vec<&String> = batch.iter().map(|kv| &kv.key).collect();
+                        match client.get(keys).timeout(timeout, "client.get").await {
+                            Ok(v) => {
+                                stats.gets += GET_BATCH_SIZE as u64;
+                                for (id, e) in v.errors {
+                                    tracing::debug!(message = "error getting items", first_key = batch.first().map(|kv| &kv.key), server = %id, err = %e);
+                                }
+                            }
+                            Err(e) => {
+                                tracing::debug!(message = "unable to get items", first_key = batch.first().map(|kv| &kv.key), err = %e);
+                            }
+                        }
+                    }
+
+                    stats.gets_time += get_start.elapsed();
+                }
+
+                stats
+            })));
+        }
+
+        // Let each of the benchmark tasks run for the given time and then set the "stop"
+        // flag which they check each test iteration.
+        tokio::time::sleep(time).await;
+        run.store(false, Ordering::Release);
+        let mut out = Vec::with_capacity(self.concurrency);
+
+        for (worker, t) in tasks {
+            match t.await {
+                Ok(m) => out.push(m),
+                Err(e) => {
+                    tracing::error!(message = "unable to run benchmark task", worker = worker, err = %e);
+                }
+            }
+        }
+
+        out
+    }
+}
+
+fn fixture_data(worker: usize, num: usize) -> Vec<KVPair> {
+    let mut out = Vec::with_capacity(num);
+    let mut rng = rand::thread_rng();
+    // Using a "lambda" value of 10 means that most numbers end up in the 0 to 1.0 range
+    // with the occasional value over 1.0. We're generating sizes of test data, so it doesn't
+    // really matter if we occasionally have values over 1.0.
+    let dist = Exp::new(10.0).unwrap();
+
+    for i in 0..num {
+        let key = format!("mc-bench-{}-{}", worker, i);
+        let unit = rng.sample(dist);
+        let size = (MAX_ITEM_SIZE as f64 * unit) as usize;
+        let val = "x".repeat(size);
+
+        out.push(KVPair {
+            key,
+            val: val.into_bytes(),
+        })
+    }
+
+    out
+}
+
+struct KVPair {
+    key: String,
+    val: Vec<u8>,
+}
+
+#[derive(Debug, Default)]
+pub struct Summary {
+    pub gets_time: Duration,
+    pub gets: u64,
+    pub sets_time: Duration,
+    pub sets: u64,
+    pub worker: usize,
+}
+
+impl Summary {
+    pub fn gets_per_sec(&self) -> f64 {
+        self.gets as f64 / self.gets_time.as_secs_f64()
+    }
+
+    pub fn sets_per_sec(&self) -> f64 {
+        self.sets as f64 / self.sets_time.as_secs_f64()
+    }
+}

--- a/mtop/src/bin/mc.rs
+++ b/mtop/src/bin/mc.rs
@@ -1,5 +1,6 @@
 use clap::{Args, Parser, Subcommand, ValueHint};
-use mtop::check::{Checker, MeasurementBundle};
+use mtop::bench::{Bencher, Percent, Summary};
+use mtop::check::{Checker, TimingBundle};
 use mtop_client::{
     DiscoveryDefault, MemcachedClient, MemcachedPool, Meta, MtopError, PoolConfig, SelectorRendezvous, Server,
     TLSConfig, Timeout, Value,
@@ -14,7 +15,8 @@ use tracing::{Instrument, Level};
 
 const DEFAULT_LOG_LEVEL: Level = Level::INFO;
 const DEFAULT_HOST: &str = "localhost:11211";
-const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+const DEFAULT_TIMEOUT_SECS: u64 = 30;
+const DEFAULT_CONNECTIONS_PER_HOST: u64 = 4;
 
 /// mc: memcached command line utility
 #[derive(Debug, Parser)]
@@ -28,6 +30,14 @@ struct McConfig {
     /// Memcached host to connect to in the form 'hostname:port'.
     #[arg(long, default_value_t = DEFAULT_HOST.to_owned(), value_hint = ValueHint::Hostname)]
     host: String,
+
+    /// Timeout for network operations, in seconds.
+    #[arg(long, default_value_t = DEFAULT_TIMEOUT_SECS)]
+    timeout_secs: u64,
+
+    /// Maximum number of idle connections to maintain per host.
+    #[arg(long, default_value_t = DEFAULT_CONNECTIONS_PER_HOST)]
+    connections: u64,
 
     /// Enable TLS connections to the Memcached server.
     #[arg(long)]
@@ -60,6 +70,7 @@ struct McConfig {
 #[derive(Debug, Subcommand)]
 enum Action {
     Add(AddCommand),
+    Bench(BenchCommand),
     Check(CheckCommand),
     Decr(DecrCommand),
     Delete(DeleteCommand),
@@ -88,16 +99,61 @@ struct AddCommand {
     ttl: u32,
 }
 
+/// Run a benchmark against the cache.
+///
+/// One or more worker threads will be spawned to run gets and sets against the cache
+/// in a loop, with `delay-millis` in between each iteration of the loop. The benchmark
+/// will run for `time-secs` and print per-worker gets and sets per second as key-value
+/// pairs.
+///
+/// The default configuration runs for 60 seconds, uses a single worker, performs 10,000
+/// gets per second, performs 500 sets per second, and writes payloads between a few
+/// hundred bytes and 128KB.
+#[derive(Debug, Args)]
+struct BenchCommand {
+    /// How long to run the benchmark for in seconds.
+    #[arg(long, default_value_t = 60)]
+    time_secs: u64,
+
+    /// How many writes to the cache as a percentage of reads from the cache, 0 to 1.
+    ///
+    /// A value of `1.0` means that for 100 gets, there will be 100 sets. A value of `0.5`
+    /// means that for 100 gets, there will be 50 sets. Default is to perform many more gets
+    /// than sets since cache workloads tend to have more reads than writes.
+    #[arg(long, default_value_t = Percent::unchecked(0.05))]
+    write_percent: Percent,
+
+    /// How many workers to run at once, performing gets and sets against the cache.
+    ///
+    /// Each worker does 10,000 gets and 500 sets per second in the default configuration.
+    #[arg(long, default_value_t = 1)]
+    concurrency: usize,
+
+    /// How long to wait between each batch of gets and sets performed against the cache.
+    ///
+    /// Each batch is 1000 gets and 50 sets by default. With a delay of 100ms this means
+    /// there will be 10,000 gets and 500 sets per second. To increase the number of gets
+    /// and sets performed by a worker, reduce this number. To decrease the number of gets
+    /// and sets performed by a worker, increase this number.
+    #[arg(long, default_value_t = 100)]
+    delay_millis: u64,
+
+    /// TTL to use for test values stored in the cache in seconds.
+    #[arg(long, default_value_t = 1800)]
+    ttl_secs: u32,
+}
+
 /// Run health checks against the cache.
+///
+/// Checks will be run repeatedly with `delay-millis` in between each iteration until
+/// `time-secs` has elapsed. Time taken to do DNS resolution, connect, set a value in
+/// the cache, and get a value from the cache will be recorded and emitted as key-value
+/// pairs at the end of the test.
 #[derive(Debug, Args)]
 struct CheckCommand {
     /// How long to run the checks for in seconds.
     #[arg(long, default_value_t = 60)]
     time_secs: u64,
-
-    /// Timeout for each portion of the check (DNS, connection, set, get) in seconds.
-    #[arg(long, default_value_t = 5)]
-    timeout_secs: u64,
 
     /// How long to wait between each health check in milliseconds.
     #[arg(long, default_value_t = 100)]
@@ -136,7 +192,7 @@ struct GetCommand {
     key: String,
 }
 
-/// Increment the value of an item in the cach
+/// Increment the value of an item in the cache.
 #[derive(Debug, Args)]
 struct IncrCommand {
     /// Key of the value to increment. If the value does not exist the command will exit with
@@ -215,20 +271,22 @@ async fn main() -> ExitCode {
         mtop::tracing::console_subscriber(opts.log_level).expect("failed to setup console logging");
     tracing::subscriber::set_global_default(console_subscriber).expect("failed to initialize console logging");
 
+    let timeout = Duration::from_secs(opts.timeout_secs);
     let resolver = DiscoveryDefault;
-    let server = match resolver.resolve(&opts.host).await.map(|mut v| v.pop()) {
-        Ok(Some(v)) => v,
-        Ok(None) => {
-            tracing::error!(message = "no names resolved for host name", hosts = ?opts.host);
-            return ExitCode::FAILURE;
-        }
+    let servers = match resolver
+        .resolve_by_proto(&opts.host)
+        .timeout(timeout, "resolver.resolve_by_proto")
+        .instrument(tracing::span!(Level::INFO, "resolver.resolve_by_proto"))
+        .await
+    {
+        Ok(v) => v,
         Err(e) => {
             tracing::error!(message = "unable to resolve host names", hosts = ?opts.host, err = %e);
             return ExitCode::FAILURE;
         }
     };
 
-    let client = match new_client(&opts, &server).await {
+    let client = match new_client(&opts, &servers).await {
         Ok(v) => v,
         Err(e) => {
             tracing::error!(message = "unable to initialize memcached client", host = opts.host, err = %e);
@@ -236,27 +294,27 @@ async fn main() -> ExitCode {
         }
     };
 
-    // Hardcoded timeout so that we can ensure the host is actually up.
-    if let Err(e) = connect(&client, CONNECT_TIMEOUT).await {
+    if let Err(e) = connect(&client, timeout).await {
         tracing::error!(message = "unable to connect", host = opts.host, err = %e);
         return ExitCode::FAILURE;
     };
 
     match &opts.mode {
         Action::Add(cmd) => run_add(&opts, cmd, &client).await,
+        Action::Bench(cmd) => run_bench(&opts, cmd, client).await,
         Action::Check(cmd) => run_check(&opts, cmd, &client, &resolver).await,
         Action::Decr(cmd) => run_decr(&opts, cmd, &client).await,
         Action::Delete(cmd) => run_delete(&opts, cmd, &client).await,
         Action::Get(cmd) => run_get(&opts, cmd, &client).await,
         Action::Incr(cmd) => run_incr(&opts, cmd, &client).await,
-        Action::Keys(cmd) => run_keys(&opts, &server, cmd, &client).await,
+        Action::Keys(cmd) => run_keys(&opts, cmd, &client).await,
         Action::Replace(cmd) => run_replace(&opts, cmd, &client).await,
         Action::Set(cmd) => run_set(&opts, cmd, &client).await,
         Action::Touch(cmd) => run_touch(&opts, cmd, &client).await,
     }
 }
 
-async fn new_client(opts: &McConfig, servers: &Server) -> Result<MemcachedClient, MtopError> {
+async fn new_client(opts: &McConfig, servers: &[Server]) -> Result<MemcachedClient, MtopError> {
     let tls = TLSConfig {
         enabled: opts.tls_enabled,
         ca_path: opts.tls_ca.clone(),
@@ -269,12 +327,13 @@ async fn new_client(opts: &McConfig, servers: &Server) -> Result<MemcachedClient
         Handle::current(),
         PoolConfig {
             tls,
+            max_idle_per_host: opts.connections,
             ..Default::default()
         },
     )
     .await
     .map(|pool| {
-        let selector = SelectorRendezvous::new(vec![servers.clone()]);
+        let selector = SelectorRendezvous::new(servers.to_vec());
         MemcachedClient::new(Handle::current(), selector, pool)
     })
 }
@@ -302,12 +361,34 @@ async fn run_add(opts: &McConfig, cmd: &AddCommand, client: &MemcachedClient) ->
         }
     };
 
-    if let Err(e) = client.add(&cmd.key, 0, cmd.ttl, &buf).await {
+    if let Err(e) = client
+        .add(&cmd.key, 0, cmd.ttl, &buf)
+        .timeout(Duration::from_secs(opts.timeout_secs), "client.add")
+        .instrument(tracing::span!(Level::INFO, "client.add"))
+        .await
+    {
         tracing::error!(message = "unable to add item", key = cmd.key, host = opts.host, err = %e);
         ExitCode::FAILURE
     } else {
         ExitCode::SUCCESS
     }
+}
+
+async fn run_bench(opts: &McConfig, cmd: &BenchCommand, client: MemcachedClient) -> ExitCode {
+    let bencher = Bencher::new(
+        client,
+        Handle::current(),
+        Duration::from_millis(cmd.delay_millis),
+        Duration::from_secs(opts.timeout_secs),
+        Duration::from_secs(cmd.ttl_secs as u64),
+        cmd.write_percent,
+        cmd.concurrency,
+    );
+
+    let measurements = bencher.run(Duration::from_secs(cmd.time_secs)).await;
+    print_bench_results(&measurements);
+
+    ExitCode::SUCCESS
 }
 
 async fn run_check(
@@ -320,12 +401,10 @@ async fn run_check(
         client,
         resolver,
         Duration::from_millis(cmd.delay_millis),
-        Duration::from_secs(cmd.timeout_secs),
+        Duration::from_secs(opts.timeout_secs),
     );
     let results = checker.run(&opts.host, Duration::from_secs(cmd.time_secs)).await;
-    if let Err(e) = print_check_results(&results).await {
-        tracing::warn!(message = "error writing output", err = %e);
-    }
+    print_check_results(&results);
 
     if results.failures.total > 0 {
         ExitCode::FAILURE
@@ -335,7 +414,12 @@ async fn run_check(
 }
 
 async fn run_decr(opts: &McConfig, cmd: &DecrCommand, client: &MemcachedClient) -> ExitCode {
-    if let Err(e) = client.decr(&cmd.key, cmd.delta).await {
+    if let Err(e) = client
+        .decr(&cmd.key, cmd.delta)
+        .timeout(Duration::from_secs(opts.timeout_secs), "client.decr")
+        .instrument(tracing::span!(Level::INFO, "client.decr"))
+        .await
+    {
         tracing::error!(message = "unable to decrement value", key = cmd.key, host = opts.host, err = %e);
         ExitCode::FAILURE
     } else {
@@ -344,7 +428,12 @@ async fn run_decr(opts: &McConfig, cmd: &DecrCommand, client: &MemcachedClient) 
 }
 
 async fn run_delete(opts: &McConfig, cmd: &DeleteCommand, client: &MemcachedClient) -> ExitCode {
-    if let Err(e) = client.delete(&cmd.key).await {
+    if let Err(e) = client
+        .delete(&cmd.key)
+        .timeout(Duration::from_secs(opts.timeout_secs), "client.delete")
+        .instrument(tracing::span!(Level::INFO, "client.delete"))
+        .await
+    {
         tracing::error!(message = "unable to delete item", key = cmd.key, host = opts.host, err = %e);
         ExitCode::FAILURE
     } else {
@@ -353,7 +442,12 @@ async fn run_delete(opts: &McConfig, cmd: &DeleteCommand, client: &MemcachedClie
 }
 
 async fn run_get(opts: &McConfig, cmd: &GetCommand, client: &MemcachedClient) -> ExitCode {
-    let response = match client.get(&[cmd.key.clone()]).await {
+    let response = match client
+        .get(&[cmd.key.clone()])
+        .timeout(Duration::from_secs(opts.timeout_secs), "client.get")
+        .instrument(tracing::span!(Level::INFO, "client.get"))
+        .await
+    {
         Ok(v) => v,
         Err(e) => {
             tracing::error!(message = "unable to get item", key = cmd.key, host = opts.host, err = %e);
@@ -379,7 +473,12 @@ async fn run_get(opts: &McConfig, cmd: &GetCommand, client: &MemcachedClient) ->
 }
 
 async fn run_incr(opts: &McConfig, cmd: &IncrCommand, client: &MemcachedClient) -> ExitCode {
-    if let Err(e) = client.incr(&cmd.key, cmd.delta).await {
+    if let Err(e) = client
+        .incr(&cmd.key, cmd.delta)
+        .timeout(Duration::from_secs(opts.timeout_secs), "client.incr")
+        .instrument(tracing::span!(Level::INFO, "client.incr"))
+        .await
+    {
         tracing::error!(message = "unable to increment value", key = cmd.key, host = opts.host, err = %e);
         ExitCode::FAILURE
     } else {
@@ -387,8 +486,13 @@ async fn run_incr(opts: &McConfig, cmd: &IncrCommand, client: &MemcachedClient) 
     }
 }
 
-async fn run_keys(opts: &McConfig, server: &Server, cmd: &KeysCommand, client: &MemcachedClient) -> ExitCode {
-    let mut response = match client.metas().await {
+async fn run_keys(opts: &McConfig, cmd: &KeysCommand, client: &MemcachedClient) -> ExitCode {
+    let response = match client
+        .metas()
+        .timeout(Duration::from_secs(opts.timeout_secs), "client.metas")
+        .instrument(tracing::span!(Level::INFO, "client.metas"))
+        .await
+    {
         Ok(v) => v,
         Err(e) => {
             tracing::error!(message = "unable to list keys", host = opts.host, err = %e);
@@ -396,7 +500,8 @@ async fn run_keys(opts: &McConfig, server: &Server, cmd: &KeysCommand, client: &
         }
     };
 
-    let mut metas = response.values.remove(&server.id()).unwrap_or_default();
+    let has_errors = response.has_errors();
+    let mut metas: Vec<Meta> = response.values.into_values().flatten().collect();
     metas.sort();
 
     if let Err(e) = print_keys(&metas, cmd.details).await {
@@ -407,7 +512,7 @@ async fn run_keys(opts: &McConfig, server: &Server, cmd: &KeysCommand, client: &
         tracing::error!(message = "error fetching metas", server = %id, err = %e);
     }
 
-    if response.has_errors() {
+    if has_errors {
         ExitCode::FAILURE
     } else {
         ExitCode::SUCCESS
@@ -423,7 +528,12 @@ async fn run_replace(opts: &McConfig, cmd: &ReplaceCommand, client: &MemcachedCl
         }
     };
 
-    if let Err(e) = client.replace(&cmd.key, 0, cmd.ttl, &buf).await {
+    if let Err(e) = client
+        .replace(&cmd.key, 0, cmd.ttl, &buf)
+        .timeout(Duration::from_secs(opts.timeout_secs), "client.replace")
+        .instrument(tracing::span!(Level::INFO, "client.replace"))
+        .await
+    {
         tracing::error!(message = "unable to replace item", key = cmd.key, host = opts.host, err = %e);
         ExitCode::FAILURE
     } else {
@@ -440,7 +550,12 @@ async fn run_set(opts: &McConfig, cmd: &SetCommand, client: &MemcachedClient) ->
         }
     };
 
-    if let Err(e) = client.set(&cmd.key, 0, cmd.ttl, &buf).await {
+    if let Err(e) = client
+        .set(&cmd.key, 0, cmd.ttl, &buf)
+        .timeout(Duration::from_secs(opts.timeout_secs), "client.set")
+        .instrument(tracing::span!(Level::INFO, "client.set"))
+        .await
+    {
         tracing::error!(message = "unable to set item", key = cmd.key, host = opts.host, err = %e);
         ExitCode::FAILURE
     } else {
@@ -449,7 +564,12 @@ async fn run_set(opts: &McConfig, cmd: &SetCommand, client: &MemcachedClient) ->
 }
 
 async fn run_touch(opts: &McConfig, cmd: &TouchCommand, client: &MemcachedClient) -> ExitCode {
-    if let Err(e) = client.touch(&cmd.key, cmd.ttl).await {
+    if let Err(e) = client
+        .touch(&cmd.key, cmd.ttl)
+        .timeout(Duration::from_secs(opts.timeout_secs), "client.touch")
+        .instrument(tracing::span!(Level::INFO, "client.touch"))
+        .await
+    {
         tracing::error!(message = "unable to touch item", key = cmd.key, host = opts.host, err = %e);
         ExitCode::FAILURE
     } else {
@@ -465,12 +585,16 @@ async fn read_input() -> io::Result<Vec<u8>> {
 }
 
 async fn print_data(val: &Value) -> io::Result<()> {
+    // Write to stdout via buffered output since we need to write raw bytes.
     let mut output = BufWriter::new(tokio::io::stdout());
     output.write_all(&val.data).await?;
     output.flush().await
 }
 
 async fn print_keys(metas: &[Meta], show_details: bool) -> io::Result<()> {
+    // Write to stdout via buffered output since keys results are usually
+    // quite big and we don't want to overhead of locking and flushing on
+    // every println!().
     let mut output = BufWriter::new(tokio::io::stdout());
 
     if show_details {
@@ -488,78 +612,64 @@ async fn print_keys(metas: &[Meta], show_details: bool) -> io::Result<()> {
     output.flush().await
 }
 
-async fn print_check_results(results: &MeasurementBundle) -> io::Result<()> {
-    let mut output = BufWriter::new(tokio::io::stdout());
+fn print_bench_results(results: &[Summary]) {
+    for m in results {
+        println!(
+            "worker={} gets={} gets_time={:.3} gets_per_second={:.0} sets={} sets_time={:.3} sets_per_second={:.0}",
+            m.worker,
+            m.gets,
+            m.gets_time.as_secs_f64(),
+            m.gets_per_sec(),
+            m.sets,
+            m.sets_time.as_secs_f64(),
+            m.sets_per_sec(),
+        );
+    }
+}
 
-    output
-        .write_all(
-            format!(
-                "type=min total={:.9} dns={:.9} connection={:.9} set={:.9} get={:.9}\n",
-                results.total.min.as_secs_f64(),
-                results.dns.min.as_secs_f64(),
-                results.connections.min.as_secs_f64(),
-                results.sets.min.as_secs_f64(),
-                results.gets.min.as_secs_f64()
-            )
-            .as_bytes(),
-        )
-        .await?;
+fn print_check_results(results: &TimingBundle) {
+    println!(
+        "type=min total={:.9} dns={:.9} connection={:.9} set={:.9} get={:.9}",
+        results.total.min.as_secs_f64(),
+        results.dns.min.as_secs_f64(),
+        results.connections.min.as_secs_f64(),
+        results.sets.min.as_secs_f64(),
+        results.gets.min.as_secs_f64()
+    );
 
-    output
-        .write_all(
-            format!(
-                "type=max total={:.9} dns={:.9} connection={:.9} set={:.9} get={:.9}\n",
-                results.total.max.as_secs_f64(),
-                results.dns.max.as_secs_f64(),
-                results.connections.max.as_secs_f64(),
-                results.sets.max.as_secs_f64(),
-                results.gets.max.as_secs_f64(),
-            )
-            .as_bytes(),
-        )
-        .await?;
+    println!(
+        "type=max total={:.9} dns={:.9} connection={:.9} set={:.9} get={:.9}",
+        results.total.max.as_secs_f64(),
+        results.dns.max.as_secs_f64(),
+        results.connections.max.as_secs_f64(),
+        results.sets.max.as_secs_f64(),
+        results.gets.max.as_secs_f64(),
+    );
 
-    output
-        .write_all(
-            format!(
-                "type=avg total={:.9} dns={:.9} connection={:.9} set={:.9} get={:.9}\n",
-                results.total.avg.as_secs_f64(),
-                results.dns.avg.as_secs_f64(),
-                results.connections.avg.as_secs_f64(),
-                results.sets.avg.as_secs_f64(),
-                results.gets.avg.as_secs_f64()
-            )
-            .as_bytes(),
-        )
-        .await?;
+    println!(
+        "type=avg total={:.9} dns={:.9} connection={:.9} set={:.9} get={:.9}",
+        results.total.avg.as_secs_f64(),
+        results.dns.avg.as_secs_f64(),
+        results.connections.avg.as_secs_f64(),
+        results.sets.avg.as_secs_f64(),
+        results.gets.avg.as_secs_f64()
+    );
 
-    output
-        .write_all(
-            format!(
-                "type=stddev total={:.9} dns={:.9} connection={:.9} set={:.9} get={:.9}\n",
-                results.total.std_dev.as_secs_f64(),
-                results.dns.std_dev.as_secs_f64(),
-                results.connections.std_dev.as_secs_f64(),
-                results.sets.std_dev.as_secs_f64(),
-                results.gets.std_dev.as_secs_f64()
-            )
-            .as_bytes(),
-        )
-        .await?;
+    println!(
+        "type=stddev total={:.9} dns={:.9} connection={:.9} set={:.9} get={:.9}",
+        results.total.std_dev.as_secs_f64(),
+        results.dns.std_dev.as_secs_f64(),
+        results.connections.std_dev.as_secs_f64(),
+        results.sets.std_dev.as_secs_f64(),
+        results.gets.std_dev.as_secs_f64()
+    );
 
-    output
-        .write_all(
-            format!(
-                "type=failures total={} dns={} connection={} set={} get={}\n",
-                results.failures.total,
-                results.failures.dns,
-                results.failures.connections,
-                results.failures.sets,
-                results.failures.gets,
-            )
-            .as_bytes(),
-        )
-        .await?;
-
-    output.flush().await
+    println!(
+        "type=failures total={} dns={} connection={} set={} get={}",
+        results.failures.total,
+        results.failures.dns,
+        results.failures.connections,
+        results.failures.sets,
+        results.failures.gets,
+    );
 }

--- a/mtop/src/lib.rs
+++ b/mtop/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::uninlined_format_args)]
 
+pub mod bench;
 pub mod check;
 pub mod queue;
 pub mod tracing;


### PR DESCRIPTION
Add support for running simplistic benchmarks against a Memcached server. The purpose of the command is to provide an easy way to send _some_ amount of traffic to a server, not provide a comprehensive benchmark tool.

Fixes #109