### PR TITLE
Profiling support and performance improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,6 +147,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
+name = "cpp_demangle"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8227005286ec39567949b33df9896bcadfa6051bccca2488129f108ca23119"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,6 +181,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,6 +203,24 @@ checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -297,6 +333,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
+name = "memmap2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,6 +369,7 @@ dependencies = [
  "clap",
  "crossterm",
  "mtop-client",
+ "pprof",
  "rand",
  "rand_distr",
  "ratatui",
@@ -344,6 +390,17 @@ dependencies = [
  "tracing",
  "urlencoding",
  "webpki-roots",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -433,6 +490,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
+name = "pprof"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef5c97c51bd34c7e742402e216abdeb44d415fbe6ae41d56b114723e953711cb"
+dependencies = [
+ "backtrace",
+ "cfg-if",
+ "findshlibs",
+ "libc",
+ "log",
+ "nix",
+ "once_cell",
+ "parking_lot",
+ "protobuf",
+ "protobuf-codegen-pure",
+ "smallvec",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,6 +524,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
+name = "protobuf-codegen"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "033460afb75cf755fcfc16dfaed20b86468082a2ea24e05ac35ab4a099a017d6"
+dependencies = [
+ "protobuf",
+]
+
+[[package]]
+name = "protobuf-codegen-pure"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a29399fc94bcd3eeaa951c715f7bea69409b2445356b00519740bcd6ddd865"
+dependencies = [
+ "protobuf",
+ "protobuf-codegen",
 ]
 
 [[package]]
@@ -682,6 +786,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,6 +820,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
+name = "symbolic-common"
+version = "12.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cccfffbc6bb3bb2d3a26cd2077f4d055f6808d266f9d4d158797a4c60510dfe"
+dependencies = [
+ "debugid",
+ "memmap2",
+ "stable_deref_trait",
+ "uuid",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "12.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a99812da4020a67e76c4eb41f08c87364c14170495ff780f30dd519c221a68"
+dependencies = [
+ "cpp_demangle",
+ "rustc-demangle",
+ "symbolic-common",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,6 +865,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,6 +885,26 @@ checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
  "rustix",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -878,6 +1044,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "uuid"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 
 [[package]]
 name = "valuable"

--- a/mtop-client/src/pool.rs
+++ b/mtop-client/src/pool.rs
@@ -160,7 +160,7 @@ impl Default for PoolConfig {
         Self {
             max_idle_per_host: 4,
             check_on_get: false,
-            check_on_put: true,
+            check_on_put: false,
             tls: TLSConfig::default(),
         }
     }

--- a/mtop/Cargo.toml
+++ b/mtop/Cargo.toml
@@ -20,6 +20,12 @@ ratatui = "0.25.0"
 tokio = { version = "1.14.0", features = ["full"] }
 tracing = "0.1.11"
 tracing-subscriber = "0.3.16"
+# Profiling, disabled by default
+pprof = {version = "0.13.0", features = ["protobuf-codec"] , optional = true}
+
+[features]
+default = []
+profile = ["dep:pprof"]
 
 [lib]
 name = "mtop"

--- a/mtop/src/bench.rs
+++ b/mtop/src/bench.rs
@@ -38,7 +38,7 @@ impl FromStr for Percent {
             .parse()
             .map_err(|e| MtopError::configuration_cause(format!("invalid percent {}", s), e))?;
 
-        if v < 0.0 || v > 1.0 {
+        if !(0.0..=1.0).contains(&v) {
             Err(MtopError::configuration(format!("invalid percent {}", v)))
         } else {
             Ok(Self(v))
@@ -98,8 +98,7 @@ impl Bencher {
 
             tasks.push((worker, self.handle.spawn(async move {
                 let kvs = fixture_data(worker, NUM_KEYS);
-                let mut stats = Summary::default();
-                stats.worker = worker;
+                let mut stats = Summary {  worker, ..Default::default() };
 
                 while run.load(Ordering::Acquire) {
                     let set_start = interval.tick().await;

--- a/mtop/src/bin/mc.rs
+++ b/mtop/src/bin/mc.rs
@@ -1,11 +1,14 @@
 use clap::{Args, Parser, Subcommand, ValueHint};
 use mtop::bench::{Bencher, Percent, Summary};
 use mtop::check::{Checker, TimingBundle};
+use mtop::profile::Profiler;
 use mtop_client::{
     DiscoveryDefault, MemcachedClient, MemcachedPool, Meta, MtopError, PoolConfig, SelectorRendezvous, Server,
     TLSConfig, Timeout, Value,
 };
-use std::path::PathBuf;
+use std::fs::File;
+use std::io::Write;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::time::Duration;
 use std::{env, io};
@@ -38,6 +41,11 @@ struct McConfig {
     /// Maximum number of idle connections to maintain per host.
     #[arg(long, default_value_t = DEFAULT_CONNECTIONS_PER_HOST)]
     connections: u64,
+
+    /// Output pprof protobuf profile data to this file if profiling support was enabled
+    /// at build time.
+    #[arg(long, value_hint = ValueHint::FilePath)]
+    profile_output: Option<PathBuf>,
 
     /// Enable TLS connections to the Memcached server.
     #[arg(long)]
@@ -299,7 +307,8 @@ async fn main() -> ExitCode {
         return ExitCode::FAILURE;
     };
 
-    match &opts.mode {
+    let profiling = Profiling::default();
+    let code = match &opts.mode {
         Action::Add(cmd) => run_add(&opts, cmd, &client).await,
         Action::Bench(cmd) => run_bench(&opts, cmd, client).await,
         Action::Check(cmd) => run_check(&opts, cmd, &client, &resolver).await,
@@ -311,6 +320,42 @@ async fn main() -> ExitCode {
         Action::Replace(cmd) => run_replace(&opts, cmd, &client).await,
         Action::Set(cmd) => run_set(&opts, cmd, &client).await,
         Action::Touch(cmd) => run_touch(&opts, cmd, &client).await,
+    };
+
+    if let Some(p) = opts.profile_output {
+        profiling.finish(p);
+    }
+
+    code
+}
+
+#[derive(Debug, Default)]
+pub struct Profiling {
+    profiler: Profiler,
+}
+
+impl Profiling {
+    pub fn finish<P>(&self, path: P)
+    where
+        P: AsRef<Path>,
+    {
+        if let Err(e) = self.profiler.proto().and_then(|b| Self::write_file(&path, &b)) {
+            tracing::warn!(message = "unable to collect and write pprof data", path = ?path.as_ref(), err = %e);
+        }
+    }
+
+    fn write_file<P>(path: P, contents: &[u8]) -> Result<(), MtopError>
+    where
+        P: AsRef<Path>,
+    {
+        if contents.is_empty() {
+            return Err(MtopError::configuration("mtop built without profiling support"));
+        }
+
+        let mut file = File::options().create(true).truncate(true).write(true).open(path)?;
+        file.write_all(contents)?;
+        file.flush()?;
+        Ok(file.sync_all()?)
     }
 }
 

--- a/mtop/src/bin/mtop.rs
+++ b/mtop/src/bin/mtop.rs
@@ -205,6 +205,7 @@ async fn new_client(opts: &MtopConfig, servers: &[Server]) -> Result<MemcachedCl
         Handle::current(),
         PoolConfig {
             tls,
+            check_on_put: true,
             ..Default::default()
         },
     )

--- a/mtop/src/lib.rs
+++ b/mtop/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod bench;
 pub mod check;
+pub mod profile;
 pub mod queue;
 pub mod tracing;
 pub mod ui;

--- a/mtop/src/profile/mod.rs
+++ b/mtop/src/profile/mod.rs
@@ -1,0 +1,9 @@
+#[cfg(not(feature = "profile"))]
+pub use nop::Profiler;
+#[cfg(feature = "profile")]
+pub use pprof::Profiler;
+
+#[cfg(not(feature = "profile"))]
+mod nop;
+#[cfg(feature = "profile")]
+mod pprof;

--- a/mtop/src/profile/nop.rs
+++ b/mtop/src/profile/nop.rs
@@ -1,0 +1,14 @@
+use mtop_client::MtopError;
+
+#[derive(Debug, Default)]
+pub struct Profiler;
+
+impl Profiler {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn proto(&self) -> Result<Vec<u8>, MtopError> {
+        Ok(Vec::new())
+    }
+}

--- a/mtop/src/profile/pprof.rs
+++ b/mtop/src/profile/pprof.rs
@@ -1,0 +1,49 @@
+use mtop_client::MtopError;
+use pprof::protos::Message;
+use pprof::{ProfilerGuard, ProfilerGuardBuilder};
+use std::ffi::c_int;
+use std::fmt;
+
+const PROFILE_FREQUENCY_HZ: c_int = 999;
+const PROFILE_BLOCK_LIST: &[&str] = &["libc", "libgcc", "pthread", "vdso"];
+
+pub struct Profiler {
+    guard: ProfilerGuard<'static>,
+}
+
+impl Profiler {
+    pub fn new() -> Self {
+        let guard = ProfilerGuardBuilder::default()
+            .frequency(PROFILE_FREQUENCY_HZ)
+            .blocklist(PROFILE_BLOCK_LIST)
+            .build()
+            .unwrap();
+
+        Self { guard }
+    }
+
+    pub fn proto(&self) -> Result<Vec<u8>, MtopError> {
+        self.guard
+            .report()
+            .build()
+            .and_then(|report| report.pprof())
+            .map_err(|e| MtopError::runtime_cause("cannot build profile report", e))
+            .and_then(|profile| {
+                profile
+                    .write_to_bytes()
+                    .map_err(|e| MtopError::runtime_cause("cannot encode as protobuf", e))
+            })
+    }
+}
+
+impl Default for Profiler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Debug for Profiler {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Profiler {{ guard: <...> }}")
+    }
+}


### PR DESCRIPTION
This change adds build-time support for collecting pprof profiling data when using the `mc` binary. Along with this, are a few performance improvements that came out of profiling.

* Don't do health checks on get or puts of connections by default. They're unnecessary most of the time and dramatically slow down benchmarks.
* Make the "score" used by rendezvous hashing simpler, just the hash of the server and key instead of taking the logarithm.
* Use a for-loop for scoring each server as part of server selection so that we don't compute the score for a particular server more than once.

Fixes #112