### PR TITLE
Implement a rudimentary DNS client for SRV record lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,7 +413,9 @@ dependencies = [
 name = "mtop-client"
 version = "0.9.0"
 dependencies = [
+ "byteorder",
  "pin-project-lite",
+ "rand",
  "rustls-pemfile",
  "rustls-webpki",
  "tokio",

--- a/mtop-client/Cargo.toml
+++ b/mtop-client/Cargo.toml
@@ -11,14 +11,16 @@ keywords = ["top", "memcached"]
 edition = "2021"
 
 [dependencies]
+byteorder = "1.5.0"
 pin-project-lite = "0.2.13"
-rustls-pemfile = "2.0.0"
+rustls-pemfile = "2.1.0"
 rustls-webpki = "0.102.0"
-tokio = { version = "1.14.0", features = ["full"] }
+tokio = { version = "1.36.0", features = ["full"] }
 tokio-rustls = { version = "0.25.0" }
-tracing = "0.1.11"
+tracing = "0.1.40"
 urlencoding = "2.1.2"
-webpki-roots = "0.26.0"
+webpki-roots = "0.26.1"
+rand = "0.8.5"
 
 [lib]
 name = "mtop_client"

--- a/mtop-client/src/dns/core.rs
+++ b/mtop-client/src/dns/core.rs
@@ -1,0 +1,249 @@
+use crate::core::MtopError;
+use std::fmt;
+use std::fmt::Display;
+use std::str::FromStr;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[repr(u16)]
+pub enum RecordType {
+    A,
+    NS,
+    CNAME,
+    SOA,
+    TXT,
+    AAAA,
+    SRV,
+    OPT,
+    Unknown(u16),
+}
+
+impl From<u16> for RecordType {
+    fn from(value: u16) -> Self {
+        match value {
+            1 => Self::A,
+            2 => Self::NS,
+            5 => Self::CNAME,
+            6 => Self::SOA,
+            16 => Self::TXT,
+            28 => Self::AAAA,
+            33 => Self::SRV,
+            41 => Self::OPT,
+            v => Self::Unknown(v),
+        }
+    }
+}
+
+impl From<RecordType> for u16 {
+    fn from(value: RecordType) -> Self {
+        match value {
+            RecordType::A => 1,
+            RecordType::NS => 2,
+            RecordType::CNAME => 5,
+            RecordType::SOA => 6,
+            RecordType::TXT => 16,
+            RecordType::AAAA => 28,
+            RecordType::SRV => 33,
+            RecordType::OPT => 41,
+            RecordType::Unknown(c) => c,
+        }
+    }
+}
+
+impl Display for RecordType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RecordType::A => write!(f, "A"),
+            RecordType::NS => write!(f, "NS"),
+            RecordType::CNAME => write!(f, "CNAME"),
+            RecordType::SOA => write!(f, "SOA"),
+            RecordType::TXT => write!(f, "TXT"),
+            RecordType::AAAA => write!(f, "AAAA"),
+            RecordType::SRV => write!(f, "SRV"),
+            RecordType::OPT => write!(f, "OPT"),
+            RecordType::Unknown(t) => write!(f, "Unknown({})", t),
+        }
+    }
+}
+
+impl FromStr for RecordType {
+    type Err = MtopError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.to_uppercase();
+        match s.as_ref() {
+            "A" => Ok(RecordType::A),
+            "NS" => Ok(RecordType::NS),
+            "CNAME" => Ok(RecordType::CNAME),
+            "SOA" => Ok(RecordType::SOA),
+            "TXT" => Ok(RecordType::TXT),
+            "AAAA" => Ok(RecordType::AAAA),
+            "SRV" => Ok(RecordType::SRV),
+            "OPT" => Ok(RecordType::OPT),
+            v => Err(MtopError::configuration(format!("unknown record type '{}'", v))),
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[repr(u16)]
+pub enum RecordClass {
+    INET,
+    CHAOS,
+    HESIOD,
+    NONE,
+    ANY,
+    Unknown(u16),
+}
+
+impl From<u16> for RecordClass {
+    fn from(value: u16) -> Self {
+        match value {
+            1 => Self::INET,
+            3 => Self::CHAOS,
+            4 => Self::HESIOD,
+            254 => Self::NONE,
+            255 => Self::ANY,
+            v => Self::Unknown(v),
+        }
+    }
+}
+
+impl From<RecordClass> for u16 {
+    fn from(value: RecordClass) -> Self {
+        match value {
+            RecordClass::INET => 1,
+            RecordClass::CHAOS => 3,
+            RecordClass::HESIOD => 4,
+            RecordClass::NONE => 254,
+            RecordClass::ANY => 255,
+            RecordClass::Unknown(c) => c,
+        }
+    }
+}
+
+impl Display for RecordClass {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RecordClass::INET => write!(f, "INET"),
+            RecordClass::HESIOD => write!(f, "HESIOD"),
+            RecordClass::CHAOS => write!(f, "CHAOS"),
+            RecordClass::NONE => write!(f, "NONE"),
+            RecordClass::ANY => write!(f, "ANY"),
+            RecordClass::Unknown(c) => write!(f, "Unknown({})", c),
+        }
+    }
+}
+
+impl FromStr for RecordClass {
+    type Err = MtopError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.to_uppercase();
+        match s.as_ref() {
+            "INET" => Ok(RecordClass::INET),
+            "HESIOD" => Ok(RecordClass::HESIOD),
+            "CHAOS" => Ok(RecordClass::CHAOS),
+            "NONE" => Ok(RecordClass::NONE),
+            "ANY" => Ok(RecordClass::ANY),
+            v => Err(MtopError::configuration(format!("unknown record class '{}'", v))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{RecordClass, RecordType};
+    use std::str::FromStr;
+
+    #[test]
+    fn test_record_type_from_u16() {
+        assert_eq!(RecordType::A, RecordType::from(1));
+        assert_eq!(RecordType::NS, RecordType::from(2));
+        assert_eq!(RecordType::CNAME, RecordType::from(5));
+        assert_eq!(RecordType::SOA, RecordType::from(6));
+        assert_eq!(RecordType::TXT, RecordType::from(16));
+        assert_eq!(RecordType::AAAA, RecordType::from(28));
+        assert_eq!(RecordType::SRV, RecordType::from(33));
+        assert_eq!(RecordType::OPT, RecordType::from(41));
+        assert_eq!(RecordType::Unknown(999), RecordType::from(999));
+    }
+
+    #[test]
+    fn test_record_type_to_u16() {
+        assert_eq!(1_u16, RecordType::A.into());
+        assert_eq!(2_u16, RecordType::NS.into());
+        assert_eq!(5_u16, RecordType::CNAME.into());
+        assert_eq!(6_u16, RecordType::SOA.into());
+        assert_eq!(16_u16, RecordType::TXT.into());
+        assert_eq!(28_u16, RecordType::AAAA.into());
+        assert_eq!(33_u16, RecordType::SRV.into());
+        assert_eq!(41_u16, RecordType::OPT.into());
+        assert_eq!(999_u16, RecordType::Unknown(999).into());
+    }
+
+    #[test]
+    fn test_record_type_display() {
+        assert_eq!("A", RecordType::A.to_string());
+        assert_eq!("NS", RecordType::NS.to_string());
+        assert_eq!("CNAME", RecordType::CNAME.to_string());
+        assert_eq!("SOA", RecordType::SOA.to_string());
+        assert_eq!("TXT", RecordType::TXT.to_string());
+        assert_eq!("AAAA", RecordType::AAAA.to_string());
+        assert_eq!("SRV", RecordType::SRV.to_string());
+        assert_eq!("OPT", RecordType::OPT.to_string());
+        assert_eq!("Unknown(999)", RecordType::Unknown(999).to_string());
+    }
+
+    #[test]
+    fn test_record_type_from_str() {
+        assert_eq!(RecordType::A, RecordType::from_str("A").unwrap());
+        assert_eq!(RecordType::NS, RecordType::from_str("NS").unwrap());
+        assert_eq!(RecordType::CNAME, RecordType::from_str("CNAME").unwrap());
+        assert_eq!(RecordType::SOA, RecordType::from_str("SOA").unwrap());
+        assert_eq!(RecordType::TXT, RecordType::from_str("TXT").unwrap());
+        assert_eq!(RecordType::AAAA, RecordType::from_str("AAAA").unwrap());
+        assert_eq!(RecordType::SRV, RecordType::from_str("SRV").unwrap());
+        assert_eq!(RecordType::OPT, RecordType::from_str("OPT").unwrap());
+        assert!(RecordType::from_str("BOGUS").is_err());
+    }
+
+    #[test]
+    fn test_record_class_from_u16() {
+        assert_eq!(RecordClass::INET, RecordClass::from(1));
+        assert_eq!(RecordClass::CHAOS, RecordClass::from(3));
+        assert_eq!(RecordClass::HESIOD, RecordClass::from(4));
+        assert_eq!(RecordClass::NONE, RecordClass::from(254));
+        assert_eq!(RecordClass::ANY, RecordClass::from(255));
+        assert_eq!(RecordClass::Unknown(512), RecordClass::from(512));
+    }
+
+    #[test]
+    fn test_record_class_to_u16() {
+        assert_eq!(1_u16, RecordClass::INET.into());
+        assert_eq!(3_u16, RecordClass::CHAOS.into());
+        assert_eq!(4_u16, RecordClass::HESIOD.into());
+        assert_eq!(254_u16, RecordClass::NONE.into());
+        assert_eq!(255_u16, RecordClass::ANY.into());
+        assert_eq!(512_u16, RecordClass::Unknown(512).into());
+    }
+
+    #[test]
+    fn test_record_class_display() {
+        assert_eq!("INET", RecordClass::INET.to_string());
+        assert_eq!("CHAOS", RecordClass::CHAOS.to_string());
+        assert_eq!("HESIOD", RecordClass::HESIOD.to_string());
+        assert_eq!("NONE", RecordClass::NONE.to_string());
+        assert_eq!("ANY", RecordClass::ANY.to_string());
+        assert_eq!("Unknown(512)", RecordClass::Unknown(512).to_string());
+    }
+
+    #[test]
+    fn test_record_class_from_str() {
+        assert_eq!(RecordClass::INET, RecordClass::from_str("INET").unwrap());
+        assert_eq!(RecordClass::CHAOS, RecordClass::from_str("CHAOS").unwrap());
+        assert_eq!(RecordClass::HESIOD, RecordClass::from_str("HESIOD").unwrap());
+        assert_eq!(RecordClass::NONE, RecordClass::from_str("NONE").unwrap());
+        assert_eq!(RecordClass::ANY, RecordClass::from_str("ANY").unwrap());
+        assert!(RecordClass::from_str("BOGUS").is_err());
+    }
+}

--- a/mtop-client/src/dns/message.rs
+++ b/mtop-client/src/dns/message.rs
@@ -1,0 +1,955 @@
+use crate::core::MtopError;
+use crate::dns::core::{RecordClass, RecordType};
+use crate::dns::name::Name;
+use crate::dns::rdata::RecordData;
+use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
+use std::fmt;
+use std::fmt::Debug;
+use std::io::Seek;
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Message {
+    id: u16,
+    flags: Flags,
+    questions: Vec<Question>,
+    answers: Vec<Record>,
+    authority: Vec<Record>,
+    extra: Vec<Record>,
+}
+
+impl Message {
+    pub fn new(id: u16, flags: Flags) -> Self {
+        Self {
+            id,
+            flags,
+            questions: Vec::new(),
+            answers: Vec::new(),
+            authority: Vec::new(),
+            extra: Vec::new(),
+        }
+    }
+
+    pub fn id(&self) -> u16 {
+        self.id
+    }
+
+    pub fn set_id(mut self, id: u16) -> Self {
+        self.id = id;
+        self
+    }
+
+    pub fn flags(&self) -> Flags {
+        self.flags
+    }
+
+    pub fn set_flags(mut self, flags: Flags) -> Self {
+        self.flags = flags;
+        self
+    }
+
+    pub fn questions(&self) -> &[Question] {
+        &self.questions
+    }
+
+    pub fn add_question(mut self, q: Question) -> Self {
+        self.questions.push(q);
+        self
+    }
+
+    pub fn answers(&self) -> &[Record] {
+        &self.answers
+    }
+
+    pub fn add_answer(mut self, r: Record) -> Self {
+        self.answers.push(r);
+        self
+    }
+
+    pub fn authority(&self) -> &[Record] {
+        &self.authority
+    }
+
+    pub fn add_authority(mut self, r: Record) -> Self {
+        self.authority.push(r);
+        self
+    }
+
+    pub fn extra(&self) -> &[Record] {
+        &self.extra
+    }
+
+    pub fn add_extra(mut self, r: Record) -> Self {
+        self.extra.push(r);
+        self
+    }
+
+    fn header(&self) -> Header {
+        assert!(self.questions.len() < u16::MAX as usize);
+        assert!(self.answers.len() < u16::MAX as usize);
+        assert!(self.authority.len() < u16::MAX as usize);
+        assert!(self.extra.len() < u16::MAX as usize);
+
+        Header {
+            id: self.id,
+            flags: self.flags,
+            num_questions: self.questions.len() as u16,
+            num_answers: self.answers.len() as u16,
+            num_authority: self.authority.len() as u16,
+            num_extra: self.extra.len() as u16,
+        }
+    }
+
+    pub fn write_network_bytes<T>(&self, mut buf: T) -> Result<(), MtopError>
+    where
+        T: WriteBytesExt,
+    {
+        let header = self.header();
+        header.write_network_bytes(&mut buf)?;
+
+        for q in self.questions.iter() {
+            q.write_network_bytes(&mut buf)?;
+        }
+
+        for r in self.answers.iter() {
+            r.write_network_bytes(&mut buf)?;
+        }
+
+        for r in self.authority.iter() {
+            r.write_network_bytes(&mut buf)?;
+        }
+
+        for r in self.extra.iter() {
+            r.write_network_bytes(&mut buf)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn read_network_bytes<T>(mut buf: T) -> Result<Self, MtopError>
+    where
+        T: ReadBytesExt + Seek,
+    {
+        let header = Header::read_network_bytes(&mut buf)?;
+
+        let mut questions = Vec::new();
+        for _ in 0..header.num_questions {
+            questions.push(Question::read_network_bytes(&mut buf)?);
+        }
+
+        let mut answers = Vec::new();
+        for _ in 0..header.num_answers {
+            answers.push(Record::read_network_bytes(&mut buf)?);
+        }
+
+        let mut authority = Vec::new();
+        for _ in 0..header.num_authority {
+            authority.push(Record::read_network_bytes(&mut buf)?);
+        }
+
+        let mut extra = Vec::new();
+        for _ in 0..header.num_extra {
+            extra.push(Record::read_network_bytes(&mut buf)?);
+        }
+
+        Ok(Self {
+            id: header.id,
+            flags: header.flags,
+            questions,
+            answers,
+            authority,
+            extra,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct Header {
+    id: u16,
+    flags: Flags,
+    num_questions: u16,
+    num_answers: u16,
+    num_authority: u16,
+    num_extra: u16,
+}
+
+impl Header {
+    fn write_network_bytes<T>(&self, mut buf: T) -> Result<(), MtopError>
+    where
+        T: WriteBytesExt,
+    {
+        buf.write_u16::<NetworkEndian>(self.id)?;
+        buf.write_u16::<NetworkEndian>(self.flags.as_u16())?;
+        buf.write_u16::<NetworkEndian>(self.num_questions)?;
+        buf.write_u16::<NetworkEndian>(self.num_answers)?;
+        buf.write_u16::<NetworkEndian>(self.num_authority)?;
+        Ok(buf.write_u16::<NetworkEndian>(self.num_extra)?)
+    }
+
+    fn read_network_bytes<T>(mut buf: T) -> Result<Self, MtopError>
+    where
+        T: ReadBytesExt,
+    {
+        let id = buf.read_u16::<NetworkEndian>()?;
+        let flags = Flags::try_from(buf.read_u16::<NetworkEndian>()?)?;
+        let num_questions = buf.read_u16::<NetworkEndian>()?;
+        let num_answers = buf.read_u16::<NetworkEndian>()?;
+        let num_authority = buf.read_u16::<NetworkEndian>()?;
+        let num_extra = buf.read_u16::<NetworkEndian>()?;
+
+        Ok(Header {
+            id,
+            flags,
+            num_questions,
+            num_answers,
+            num_authority,
+            num_extra,
+        })
+    }
+}
+
+#[derive(Default, Copy, Clone, Eq, PartialEq)]
+#[repr(transparent)]
+pub struct Flags(u16);
+
+impl Flags {
+    const MASK_QR: u16 = 0b1000_0000_0000_0000;
+    // query / response
+    const MASK_OP: u16 = 0b0111_1000_0000_0000;
+    // 4 bits, op code
+    const MASK_AA: u16 = 0b0000_0100_0000_0000;
+    // authoritative answer
+    const MASK_TC: u16 = 0b0000_0010_0000_0000;
+    // truncated
+    const MASK_RD: u16 = 0b0000_0001_0000_0000;
+    // recursion desired
+    const MASK_RA: u16 = 0b0000_0000_1000_0000;
+    // recursion available
+    const MASK_RC: u16 = 0b0000_0000_0000_1111; // 4 bits, response code
+
+    const OFFSET_QR: usize = 15;
+    const OFFSET_OP: usize = 11;
+    const OFFSET_AA: usize = 10;
+    const OFFSET_TC: usize = 9;
+    const OFFSET_RD: usize = 8;
+    const OFFSET_RA: usize = 7;
+    const OFFSET_RC: usize = 0;
+
+    pub fn is_query(&self) -> bool {
+        !(self.0 & Self::MASK_QR) > 0
+    }
+
+    pub fn set_query(self) -> Self {
+        Flags(self.0 & !Self::MASK_QR)
+    }
+
+    pub fn is_response(&self) -> bool {
+        self.0 & Self::MASK_QR > 0
+    }
+
+    pub fn set_response(self) -> Self {
+        Flags(self.0 | Self::MASK_QR)
+    }
+
+    pub fn get_op_code(&self) -> Operation {
+        Operation::try_from((self.0 & Self::MASK_OP) >> Self::OFFSET_OP).unwrap()
+    }
+
+    pub fn set_op_code(self, op: Operation) -> Self {
+        let op = (op as u16) << Self::OFFSET_OP;
+        Flags(self.0 | op)
+    }
+
+    pub fn is_authoritative(&self) -> bool {
+        self.0 & Self::MASK_AA > 0
+    }
+
+    pub fn set_authoritative(self) -> Self {
+        Flags(self.0 | Self::MASK_AA)
+    }
+
+    pub fn is_truncated(&self) -> bool {
+        self.0 & Self::MASK_TC > 0
+    }
+
+    pub fn set_truncated(self) -> Self {
+        Flags(self.0 | Self::MASK_TC)
+    }
+
+    pub fn is_recursion_desired(&self) -> bool {
+        self.0 & Self::MASK_RD > 0
+    }
+
+    pub fn set_recursion_desired(self) -> Self {
+        Flags(self.0 | Self::MASK_RD)
+    }
+
+    pub fn is_recursion_available(&self) -> bool {
+        self.0 & Self::MASK_RA > 0
+    }
+
+    pub fn set_recursion_available(self) -> Self {
+        Flags(self.0 | Self::MASK_RA)
+    }
+
+    pub fn get_response_code(&self) -> ResponseCode {
+        ResponseCode::try_from((self.0 & Self::MASK_RC) >> Self::OFFSET_RC).unwrap()
+    }
+
+    pub fn set_response_code(self, code: ResponseCode) -> Self {
+        let code = (code as u16) << Self::OFFSET_RC;
+        Flags(self.0 | code)
+    }
+
+    pub fn as_u16(&self) -> u16 {
+        self.0
+    }
+}
+
+impl TryFrom<u16> for Flags {
+    type Error = MtopError;
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        // Ensure that operation and response code are valid values but
+        // otherwise use the value as is. The rest of the fields are on/off
+        // bits so any combination is valid even if they don't make sense.
+        let _op = Operation::try_from((value & Self::MASK_OP) >> Self::OFFSET_OP)?;
+        let _rc = ResponseCode::try_from((value & Self::MASK_RC) >> Self::OFFSET_RC)?;
+        Ok(Flags(value))
+    }
+}
+
+impl Debug for Flags {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let qr = (self.0 & Self::MASK_QR) >> Self::OFFSET_QR;
+        let op = Operation::try_from((self.0 & Self::MASK_OP) >> Self::OFFSET_OP).unwrap();
+        let aa = (self.0 & Self::MASK_AA) >> Self::OFFSET_AA;
+        let tc = (self.0 & Self::MASK_TC) >> Self::OFFSET_TC;
+        let rd = (self.0 & Self::MASK_RD) >> Self::OFFSET_RD;
+        let ra = (self.0 & Self::MASK_RA) >> Self::OFFSET_RA;
+        let rc = ResponseCode::try_from((self.0 & Self::MASK_RC) >> Self::OFFSET_RC).unwrap();
+
+        write!(
+            f,
+            "Flags{{qr = {qr}, op = {op:?}, aa = {aa}, tc = {tc}, rd = {rd}, ra = {ra}, rc = {rc:?}}}"
+        )
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[repr(u16)]
+pub enum ResponseCode {
+    NoError = 0,
+    FormatError = 1,
+    ServerFailure = 2,
+    NameError = 3,
+    NotImplemented = 4,
+    Refused = 5,
+    YxDomain = 6,
+    YxRrSet = 7,
+    NxRrSet = 8,
+    NotAuth = 9,
+    NotZone = 10,
+}
+
+impl Default for ResponseCode {
+    fn default() -> Self {
+        Self::NoError
+    }
+}
+
+impl TryFrom<u16> for ResponseCode {
+    type Error = MtopError;
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(ResponseCode::NoError),
+            1 => Ok(ResponseCode::FormatError),
+            2 => Ok(ResponseCode::ServerFailure),
+            3 => Ok(ResponseCode::NameError),
+            4 => Ok(ResponseCode::NotImplemented),
+            5 => Ok(ResponseCode::Refused),
+            6 => Ok(ResponseCode::YxDomain),
+            7 => Ok(ResponseCode::YxRrSet),
+            8 => Ok(ResponseCode::NxRrSet),
+            9 => Ok(ResponseCode::NotAuth),
+            10 => Ok(ResponseCode::NotZone),
+            _ => Err(MtopError::runtime(format!(
+                "invalid or unsupported response code {}",
+                value
+            ))),
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[repr(u16)]
+pub enum Operation {
+    Query = 0,
+    IQuery = 1,
+    Status = 2,
+    Notify = 4,
+    Update = 5,
+}
+
+impl Default for Operation {
+    fn default() -> Self {
+        Self::Query
+    }
+}
+
+impl TryFrom<u16> for Operation {
+    type Error = MtopError;
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Operation::Query),
+            1 => Ok(Operation::IQuery),
+            2 => Ok(Operation::Status),
+            4 => Ok(Operation::Notify),
+            5 => Ok(Operation::Update),
+            _ => Err(MtopError::runtime(format!(
+                "invalid or unsupported operation {}",
+                value
+            ))),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Question {
+    name: Name,
+    qtype: RecordType,
+    qclass: RecordClass,
+}
+
+impl Question {
+    pub fn new(name: Name, qtype: RecordType) -> Self {
+        Self {
+            name,
+            qtype,
+            qclass: RecordClass::INET,
+        }
+    }
+
+    pub fn set_qclass(mut self, qclass: RecordClass) -> Self {
+        self.qclass = qclass;
+        self
+    }
+
+    pub fn name(&self) -> &Name {
+        &self.name
+    }
+
+    pub fn qtype(&self) -> RecordType {
+        self.qtype
+    }
+
+    pub fn qclass(&self) -> RecordClass {
+        self.qclass
+    }
+
+    pub fn write_network_bytes<T>(&self, mut buf: T) -> Result<(), MtopError>
+    where
+        T: WriteBytesExt,
+    {
+        self.name.write_network_bytes(&mut buf)?;
+        buf.write_u16::<NetworkEndian>(self.qtype.into())?;
+        Ok(buf.write_u16::<NetworkEndian>(self.qclass.into())?)
+    }
+
+    pub fn read_network_bytes<T>(mut buf: T) -> Result<Self, MtopError>
+    where
+        T: ReadBytesExt + Seek,
+    {
+        let name = Name::read_network_bytes(&mut buf)?;
+        let qtype = RecordType::from(buf.read_u16::<NetworkEndian>()?);
+        let qclass = RecordClass::from(buf.read_u16::<NetworkEndian>()?);
+        Ok(Self { name, qtype, qclass })
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Record {
+    name: Name,
+    rtype: RecordType,
+    rclass: RecordClass,
+    ttl: u32,
+    rdata: RecordData,
+}
+
+impl Record {
+    pub fn new(name: Name, rtype: RecordType, rclass: RecordClass, ttl: u32, rdata: RecordData) -> Self {
+        Self {
+            name,
+            rtype,
+            rclass,
+            ttl,
+            rdata,
+        }
+    }
+
+    pub fn name(&self) -> &Name {
+        &self.name
+    }
+
+    pub fn rtype(&self) -> RecordType {
+        self.rtype
+    }
+
+    pub fn rclass(&self) -> RecordClass {
+        self.rclass
+    }
+
+    pub fn ttl(&self) -> u32 {
+        self.ttl
+    }
+
+    pub fn rdata(&self) -> &RecordData {
+        &self.rdata
+    }
+
+    pub fn write_network_bytes<T>(&self, mut buf: T) -> Result<(), MtopError>
+    where
+        T: WriteBytesExt,
+    {
+        self.name.write_network_bytes(&mut buf)?;
+        buf.write_u16::<NetworkEndian>(self.rtype.into())?;
+        buf.write_u16::<NetworkEndian>(self.rclass.into())?;
+        buf.write_u32::<NetworkEndian>(self.ttl)?;
+        buf.write_u16::<NetworkEndian>(self.rdata.size())?;
+        self.rdata.write_network_bytes(&mut buf)
+    }
+
+    pub fn read_network_bytes<T>(mut buf: T) -> Result<Self, MtopError>
+    where
+        T: ReadBytesExt + Seek,
+    {
+        let name = Name::read_network_bytes(&mut buf)?;
+        let rtype = RecordType::from(buf.read_u16::<NetworkEndian>()?);
+        let rclass = RecordClass::from(buf.read_u16::<NetworkEndian>()?);
+        let ttl = buf.read_u32::<NetworkEndian>()?;
+        let rdata_len = buf.read_u16::<NetworkEndian>()?;
+        let rdata = RecordData::read_network_bytes(rtype, rdata_len, &mut buf)?;
+
+        Ok(Self {
+            name,
+            rtype,
+            rclass,
+            ttl,
+            rdata,
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{Flags, Header, Message, Operation, Question, Record, ResponseCode};
+    use crate::dns::core::{RecordClass, RecordType};
+    use crate::dns::name::Name;
+    use crate::dns::rdata::{RecordData, RecordDataA, RecordDataSRV};
+    use std::io::Cursor;
+    use std::net::Ipv4Addr;
+    use std::str::FromStr;
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_message_write_network_bytes() {
+        let question = Question::new(Name::from_str("_cache._tcp.example.com.").unwrap(), RecordType::SRV);
+        let answer_rdata = RecordData::SRV(RecordDataSRV::new(
+            10,
+            10,
+            11211,
+            Name::from_str("cache01.example.com.").unwrap(),
+        ));
+        let answer = Record::new(
+            Name::from_str("_cache._tcp.example.com.").unwrap(),
+            RecordType::SRV,
+            RecordClass::INET,
+            300,
+            answer_rdata,
+        );
+        let extra_rdata = RecordData::A(RecordDataA::new(Ipv4Addr::new(127, 0, 0, 100)));
+        let extra = Record::new(
+            Name::from_str("cache01.example.com.").unwrap(),
+            RecordType::A,
+            RecordClass::INET,
+            60,
+            extra_rdata,
+        );
+
+        let message = Message::new(
+            65333, Flags::default()
+                .set_response()
+                .set_op_code(Operation::Query)
+                .set_response_code(ResponseCode::NoError))
+            .add_question(question)
+            .add_answer(answer)
+            .add_extra(extra);
+
+        let mut cur = Cursor::new(Vec::new());
+        message.write_network_bytes(&mut cur).unwrap();
+        let buf = cur.into_inner();
+
+        assert_eq!(
+            vec![
+                // Header
+                255, 53, // ID
+                128, 0,  // Flags: response, query op, no error
+                0, 1,    // questions
+                0, 1,    // answers
+                0, 0,    // authority
+                0, 1,    // extra
+
+                // Question
+                6,                                // length
+                95, 99, 97, 99, 104, 101,         // "_cache"
+                4,                                // length
+                95, 116, 99, 112,                 // "_tcp"
+                7,                                // length
+                101, 120, 97, 109, 112, 108, 101, // "example"
+                3,                                // length
+                99, 111, 109,                     // "com"
+                0,                                // root
+                0, 33,                            // record type, SRV
+                0, 1,                             // record class, INET
+
+                // Answer
+                6,                                // length
+                95, 99, 97, 99, 104, 101,         // "_cache"
+                4,                                // length
+                95, 116, 99, 112,                 // "_tcp"
+                7,                                // length
+                101, 120, 97, 109, 112, 108, 101, // "example"
+                3,                                // length
+                99, 111, 109,                     // "com"
+                0,                                // root
+                0, 33,                            // record type, SRV
+                0, 1,                             // record class, INET
+                0, 0, 1, 44,                      // TTL
+                0, 27,                            // rdata size
+                0, 10,                            // priority
+                0, 10,                            // weight
+                43, 203,                          // port
+                7,                                // length
+                99, 97, 99, 104, 101, 48, 49,     // "cache01"
+                7,                                // length
+                101, 120, 97, 109, 112, 108, 101, // "example"
+                3,                                // length
+                99, 111, 109,                     // "com"
+                0,                                // root
+
+                // Extra
+                7,                                // length
+                99, 97, 99, 104, 101, 48, 49,     // "cache01"
+                7,                                // length
+                101, 120, 97, 109, 112, 108, 101, // "example"
+                3,                                // length
+                99, 111, 109,                     // "com"
+                0,                                // root
+                0, 1,                             // record type, A
+                0, 1,                             // record class, INET
+                0, 0, 0, 60,                      // TTL
+                0, 4,                             // rdata size
+                127, 0, 0, 100,                   // rdata, A address
+            ],
+            buf,
+        );
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_message_read_network_bytes() {
+        let cur = Cursor::new(vec![
+            // Header
+            255, 53, // ID
+            128, 0,  // Flags: response, query op, no error
+            0, 1,    // questions
+            0, 1,    // answers
+            0, 0,    // authority
+            0, 1,    // extra
+
+            // Question
+            6,                                // length
+            95, 99, 97, 99, 104, 101,         // "_cache"
+            4,                                // length
+            95, 116, 99, 112,                 // "_tcp"
+            7,                                // length
+            101, 120, 97, 109, 112, 108, 101, // "example"
+            3,                                // length
+            99, 111, 109,                     // "com"
+            0,                                // root
+            0, 33,                            // record type, SRV
+            0, 1,                             // record class, INET
+
+            // Answer
+            6,                                // length
+            95, 99, 97, 99, 104, 101,         // "_cache"
+            4,                                // length
+            95, 116, 99, 112,                 // "_tcp"
+            7,                                // length
+            101, 120, 97, 109, 112, 108, 101, // "example"
+            3,                                // length
+            99, 111, 109,                     // "com"
+            0,                                // root
+            0, 33,                            // record type, SRV
+            0, 1,                             // record class, INET
+            0, 0, 1, 44,                      // TTL
+            0, 27,                            // rdata size
+            0, 10,                            // priority
+            0, 10,                            // weight
+            43, 203,                          // port
+            7,                                // length
+            99, 97, 99, 104, 101, 48, 49,     // "cache01"
+            7,                                // length
+            101, 120, 97, 109, 112, 108, 101, // "example"
+            3,                                // length
+            99, 111, 109,                     // "com"
+            0,                                // root
+
+            // Extra
+            7,                                // length
+            99, 97, 99, 104, 101, 48, 49,     // "cache01"
+            7,                                // length
+            101, 120, 97, 109, 112, 108, 101, // "example"
+            3,                                // length
+            99, 111, 109,                     // "com"
+            0,                                // root
+            0, 1,                             // record type, A
+            0, 1,                             // record class, INET
+            0, 0, 0, 60,                      // TTL
+            0, 4,                             // rdata size
+            127, 0, 0, 100,                   // rdata, A address
+        ]);
+
+        let message = Message::read_network_bytes(cur).unwrap();
+        assert_eq!(65333, message.id());
+        assert_eq!(
+            Flags::default()
+                .set_response()
+                .set_response_code(ResponseCode::NoError)
+                .set_op_code(Operation::Query),
+            message.flags()
+        );
+
+        let questions = message.questions();
+        assert_eq!("_cache._tcp.example.com.", questions[0].name().to_string());
+        assert_eq!(RecordType::SRV, questions[0].qtype());
+        assert_eq!(RecordClass::INET, questions[0].qclass());
+
+        let answers = message.answers();
+        assert_eq!("_cache._tcp.example.com.", answers[0].name().to_string());
+        assert_eq!(RecordType::SRV, answers[0].rtype());
+        assert_eq!(RecordClass::INET, answers[0].rclass());
+        assert_eq!(300, answers[0].ttl());
+
+        if let RecordData::SRV(rd) = answers[0].rdata() {
+            assert_eq!(10, rd.weight());
+            assert_eq!(10, rd.priority());
+            assert_eq!(11211, rd.port());
+            assert_eq!("cache01.example.com.", rd.target().to_string());
+        } else {
+            panic!("unexpected record data type: {:?}", answers[0].rdata());
+        }
+
+        let extra = message.extra();
+        assert_eq!("cache01.example.com.", extra[0].name().to_string());
+        assert_eq!(RecordType::A, extra[0].rtype());
+        assert_eq!(RecordClass::INET, extra[0].rclass());
+        assert_eq!(60, extra[0].ttl());
+
+        if let RecordData::A(rd) = extra[0].rdata() {
+            assert_eq!(Ipv4Addr::new(127, 0, 0, 100), rd.addr());
+        } else {
+            panic!("unexpected record data type: {:?}", extra[0].rdata());
+        }
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_header_write_network_bytes() {
+        let h = Header {
+            id: 65333,
+            flags: Flags::default().set_recursion_desired(),
+            num_questions: 1,
+            num_answers: 2,
+            num_authority: 3,
+            num_extra: 4,
+        };
+        let mut cur = Cursor::new(Vec::new());
+        h.write_network_bytes(&mut cur).unwrap();
+        let buf = cur.into_inner();
+
+        assert_eq!(
+            vec![
+                255, 53, // ID
+                1, 0,    // Flags, recursion desired
+                0, 1,    // questions
+                0, 2,    // answers
+                0, 3,    // authority
+                0, 4,    // extra
+            ],
+            buf,
+        )
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_header_read_network_bytes() {
+        let cur = Cursor::new(vec![
+            255, 53, // ID
+            1, 0,    // Flags, recursion desired
+            0, 1,    // questions
+            0, 2,    // answers,
+            0, 3,    // authority
+            0, 4,    // extra
+        ]);
+
+        let h = Header::read_network_bytes(cur).unwrap();
+        assert_eq!(65333, h.id);
+        assert_eq!(Flags::default().set_recursion_desired(), h.flags);
+        assert_eq!(1, h.num_questions);
+        assert_eq!(2, h.num_answers);
+        assert_eq!(3, h.num_authority);
+        assert_eq!(4, h.num_extra);
+    }
+
+    #[test]
+    fn test_flags() {
+        let f = Flags::default().set_query();
+        assert!(f.is_query());
+
+        let f = Flags::default().set_response();
+        assert!(f.is_response());
+
+        let f = Flags::default().set_op_code(Operation::Notify);
+        assert_eq!(Operation::Notify, f.get_op_code());
+
+        let f = Flags::default().set_authoritative();
+        assert!(f.is_authoritative());
+
+        let f = Flags::default().set_truncated();
+        assert!(f.is_truncated());
+
+        let f = Flags::default().set_recursion_desired();
+        assert!(f.is_recursion_desired());
+
+        let f = Flags::default().set_recursion_available();
+        assert!(f.is_recursion_available());
+
+        let f = Flags::default().set_response_code(ResponseCode::ServerFailure);
+        assert_eq!(ResponseCode::ServerFailure, f.get_response_code());
+
+        let f = Flags::default()
+            .set_query()
+            .set_recursion_desired()
+            .set_op_code(Operation::Query);
+        assert!(f.is_query());
+        assert!(f.is_recursion_desired());
+        assert_eq!(Operation::Query, f.get_op_code());
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_question_write_network_bytes() {
+        let q = Question::new(Name::from_str("example.com.").unwrap(), RecordType::AAAA);
+        let mut cur = Cursor::new(Vec::new());
+        q.write_network_bytes(&mut cur).unwrap();
+        let buf = cur.into_inner();
+
+        assert_eq!(
+            vec![
+                7,                                // length
+                101, 120, 97, 109, 112, 108, 101, // "example"
+                3,                                // length
+                99, 111, 109,                     // "com"
+                0,                                // root
+                0, 28,                            // AAAA record
+                0, 1,                             // INET class
+            ],
+            buf,
+        );
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_question_read_network_bytes() {
+        let cur = Cursor::new(vec![
+            7,                                // length
+            101, 120, 97, 109, 112, 108, 101, // "example"
+            3,                                // length
+            99, 111, 109,                     // "com"
+            0,                                // root
+            0, 28,                            // AAAA record
+            0, 1,                             // INET class
+        ]);
+
+        let q = Question::read_network_bytes(cur).unwrap();
+        assert_eq!("example.com.", q.name().to_string());
+        assert_eq!(RecordType::AAAA, q.qtype());
+        assert_eq!(RecordClass::INET, q.qclass());
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_record_write_network_bytes() {
+        let rr = Record::new(
+            Name::from_str("www.example.com.").unwrap(),
+            RecordType::A,
+            RecordClass::INET,
+            300,
+            RecordData::A(RecordDataA::new(Ipv4Addr::new(127, 0, 0, 100))),
+        );
+        let mut cur = Cursor::new(Vec::new());
+        rr.write_network_bytes(&mut cur).unwrap();
+        let buf = cur.into_inner();
+
+        assert_eq!(
+            vec![
+                3,                                // length
+                119, 119, 119,                    // "www"
+                7,                                // length
+                101, 120, 97, 109, 112, 108, 101, // "example"
+                3,                                // length
+                99, 111, 109,                     // "com"
+                0,                                // root
+                0, 1,                             // record type, A
+                0, 1,                             // record class, INET
+                0, 0, 1, 44,                      // TTL
+                0, 4,                             // rdata size
+                127, 0, 0, 100,                   // rdata, A address
+            ],
+            buf,
+        )
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_record_read_network_bytes() {
+        let cur = Cursor::new(vec![
+            3,                                // length
+            119, 119, 119,                    // "www"
+            7,                                // length
+            101, 120, 97, 109, 112, 108, 101, // "example"
+            3,                                // length
+            99, 111, 109,                     // "com"
+            0,                                // root
+            0, 1,                             // record type, A
+            0, 1,                             // record class, INET
+            0, 0, 1, 44,                      // TTL
+            0, 4,                             // rdata size
+            127, 0, 0, 100,                   // rdata, A address
+        ]);
+
+        let rr = Record::read_network_bytes(cur).unwrap();
+        assert_eq!("www.example.com.", rr.name().to_string());
+        assert_eq!(RecordType::A, rr.rtype());
+        assert_eq!(RecordClass::INET, rr.rclass());
+        assert_eq!(300, rr.ttl());
+
+        if let RecordData::A(rd) = rr.rdata() {
+            assert_eq!(Ipv4Addr::new(127, 0, 0, 100), rd.addr());
+        } else {
+            panic!("unexpected rdata type: {:?}", rr.rdata());
+        }
+    }
+}

--- a/mtop-client/src/dns/mod.rs
+++ b/mtop-client/src/dns/mod.rs
@@ -1,0 +1,40 @@
+mod core;
+mod message;
+mod name;
+mod rdata;
+
+pub use crate::dns::core::{RecordClass, RecordType};
+pub use crate::dns::message::{Flags, Message, Operation, Question, Record, ResponseCode};
+pub use crate::dns::name::Name;
+pub use crate::dns::rdata::{
+    RecordData, RecordDataA, RecordDataAAAA, RecordDataCNAME, RecordDataNS, RecordDataSOA, RecordDataSRV,
+    RecordDataTXT, RecordDataUnknown,
+};
+
+use crate::core::MtopError;
+use std::io::Cursor;
+use tokio::net::UdpSocket;
+
+const DEFAULT_RECV_BUF: usize = 512;
+
+pub fn id() -> u16 {
+    rand::random()
+}
+
+pub async fn send(sock: &UdpSocket, msg: &Message) -> Result<(), MtopError> {
+    let mut buf = Vec::new();
+    msg.write_network_bytes(&mut buf)?;
+    Ok(sock.send(&buf).await.map(|_| ())?)
+}
+
+pub async fn recv(sock: &UdpSocket, id: u16) -> Result<Message, MtopError> {
+    let mut buf = vec![0_u8; DEFAULT_RECV_BUF];
+    loop {
+        let n = sock.recv(&mut buf).await?;
+        let cur = Cursor::new(&buf[0..n]);
+        let msg = Message::read_network_bytes(cur)?;
+        if msg.id() == id {
+            return Ok(msg);
+        }
+    }
+}

--- a/mtop-client/src/dns/name.rs
+++ b/mtop-client/src/dns/name.rs
@@ -1,0 +1,412 @@
+use crate::core::MtopError;
+use byteorder::{ReadBytesExt, WriteBytesExt};
+use std::fmt;
+use std::fmt::Display;
+use std::io::{Read, Seek, SeekFrom};
+use std::str::FromStr;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Name {
+    labels: Vec<String>,
+}
+
+impl Name {
+    const MAX_LENGTH: usize = 255;
+    const MAX_LABEL_LENGTH: usize = 63;
+    const MAX_POINTERS: u32 = 64;
+
+    pub fn root() -> Self {
+        Name { labels: Vec::new() }
+    }
+
+    pub fn size(&self) -> u16 {
+        (self.labels.iter().map(|l| l.len()).sum::<usize>() + self.labels.len()) as u16 + 1
+    }
+
+    pub fn is_root(&self) -> bool {
+        self.labels.is_empty()
+    }
+
+    pub fn write_network_bytes<T>(&self, mut buf: T) -> Result<(), MtopError>
+    where
+        T: WriteBytesExt,
+    {
+        for label in self.labels.iter() {
+            buf.write_u8(label.len() as u8)?;
+            buf.write_all(label.as_bytes())?;
+        }
+
+        Ok(buf.write_u8(0)?)
+    }
+
+    pub fn read_network_bytes<T>(mut buf: T) -> Result<Self, MtopError>
+    where
+        T: ReadBytesExt + Seek,
+    {
+        let mut parts = Vec::new();
+        loop {
+            let len = buf.read_u8()?;
+            // If the length isn't a length but actually a pointer to another name
+            // or label within the message, seek to that position within the message
+            // and read the name from there. `read_offset_into` will follow any further
+            // offsets and read the labels for the name into `parts`. After resolving
+            // all pointers and reading labels, reset the stream back to immediately
+            // after the pointer.
+            if Self::is_offset(len) {
+                let offset = Self::get_offset(len, buf.read_u8()?);
+                let current = buf.stream_position()?;
+                Self::read_offset_into(&mut buf, offset, &mut parts)?;
+                buf.seek(SeekFrom::Start(current))?;
+                break;
+            }
+
+            // If the length is a length, read the next label (segment) of the name breaking
+            // the loop once we read the "root" label (`.`) signified by a length of 0.
+            if Self::read_label_into(&mut buf, len, &mut parts)? {
+                break;
+            }
+        }
+
+        String::from_utf8(parts)
+            .map_err(|e| MtopError::runtime_cause("invalid name", e))
+            .and_then(|s| Self::from_str(&s))
+    }
+
+    fn read_offset_into<T>(mut buf: T, offset: u64, out: &mut Vec<u8>) -> Result<(), MtopError>
+    where
+        T: ReadBytesExt + Seek,
+    {
+        buf.seek(SeekFrom::Start(offset))?;
+        let mut pointers = 1;
+
+        loop {
+            // To avoid loops from badly behaved servers, only follow a fixed number of
+            // pointers when trying to resolve a single name. This number is picked to be
+            // much higher than most names will use but still finite.
+            if pointers > Self::MAX_POINTERS {
+                return Err(MtopError::runtime(format!(
+                    "reached max number of pointers ({}) while reading name",
+                    Self::MAX_POINTERS
+                )));
+            }
+
+            let len = buf.read_u8()?;
+            if Self::is_offset(len) {
+                // If this length is actually a pointer to another name or label within
+                // the message, seek there to read it on the next iteration. We don't
+                // bother keeping track of where to seek back to after resolving it because
+                // this is unnecessary since we're already resolving a pointer if this
+                // method is being called from `read_ne_bytes`.
+                let offset = Self::get_offset(len, buf.read_u8()?);
+                buf.seek(SeekFrom::Start(offset))?;
+                pointers += 1;
+                continue;
+            }
+
+            // If the length is a length, read the next label (segment) of the name
+            // returning once we read the "root" label (`.`) signified by a length of 0.
+            if Self::read_label_into(&mut buf, len, out)? {
+                return Ok(());
+            }
+        }
+    }
+
+    /// Read the next name label of length `len` into `out` and return true if the
+    /// label was the root label (`.`) and this name is complete, false otherwise.
+    fn read_label_into<T>(buf: T, len: u8, out: &mut Vec<u8>) -> Result<bool, MtopError>
+    where
+        T: ReadBytesExt + Seek,
+    {
+        if len == 0 {
+            return Ok(true);
+        }
+
+        // Only six bits of the length are supposed to be used to encode the
+        // length of a label so 63 is the max length but double check just in
+        // case one of the pointer bits was set for some reason.
+        if len as usize > Self::MAX_LABEL_LENGTH {
+            return Err(MtopError::runtime(format!(
+                "max size for label would be exceeded reading {} bytes",
+                len,
+            )));
+        }
+
+        if len as usize + out.len() + 1 > Self::MAX_LENGTH {
+            return Err(MtopError::runtime(format!(
+                "max size for name would be exceeded adding {} bytes to {}",
+                len,
+                out.len()
+            )));
+        }
+
+        let mut handle = buf.take(len as u64);
+        let n = handle.read_to_end(out)?;
+        if n != len as usize {
+            return Err(MtopError::runtime(format!(
+                "short read for Name segment. expected {} got {}",
+                len, n
+            )));
+        }
+
+        out.push(b'.');
+        Ok(false)
+    }
+
+    fn is_offset(len: u8) -> bool {
+        // The top two bits of the length byte of a name label (section) are used
+        // to indicate the name is actually an offset in the DNS message to a previous
+        // name to avoid duplicating the same names over and over.
+        len & 0b1100_0000 == 192
+    }
+
+    fn get_offset(len: u8, next: u8) -> u64 {
+        let pointer = ((len & 0b0011_1111) as u16) << 8;
+        (pointer | (next as u16)) as u64
+    }
+}
+
+impl Display for Name {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.", self.labels.join("."))
+    }
+}
+
+impl FromStr for Name {
+    type Err = MtopError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() || s == "." {
+            return Ok(Self::root());
+        }
+
+        if s.len() > Self::MAX_LENGTH {
+            return Err(MtopError::runtime(format!(
+                "Names are limited to {} bytes max: {}",
+                Self::MAX_LENGTH,
+                s
+            )));
+        }
+
+        if !s.ends_with('.') {
+            return Err(MtopError::runtime(format!(
+                "Names must be fully qualified and end with a '.': {}",
+                s
+            )));
+        }
+
+        let mut labels = Vec::new();
+        for label in s.trim_end_matches('.').split('.') {
+            let len = label.len();
+            if len > Self::MAX_LABEL_LENGTH {
+                return Err(MtopError::runtime(format!(
+                    "Name labels are limited to {} bytes max: {}",
+                    Self::MAX_LABEL_LENGTH,
+                    label
+                )));
+            }
+
+            for (i, c) in label.char_indices() {
+                if i == 0 && !c.is_ascii_alphanumeric() && c != '_' {
+                    return Err(MtopError::runtime(format!(
+                        "label must begin with ASCII letter, number, or underscore: {}",
+                        label
+                    )));
+                } else if i == len - 1 && !c.is_ascii_alphanumeric() {
+                    return Err(MtopError::runtime(format!(
+                        "label must end with ASCII letter or number: {}",
+                        label
+                    )));
+                } else if !c.is_ascii_alphanumeric() && c != '-' && c != '_' {
+                    return Err(MtopError::runtime(format!(
+                        "label must be ASCII letter, number, hyphen, or underscore: {}",
+                        label
+                    )));
+                }
+            }
+
+            labels.push(label.to_lowercase());
+        }
+
+        Ok(Name { labels })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Name;
+    use std::io::Cursor;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_name_from_str_max_length() {
+        let parts = vec![
+            "a".repeat(Name::MAX_LABEL_LENGTH),
+            "b".repeat(Name::MAX_LABEL_LENGTH),
+            "c".repeat(Name::MAX_LABEL_LENGTH),
+            "d".repeat(Name::MAX_LABEL_LENGTH),
+            "com.".to_owned(),
+        ];
+        let res = Name::from_str(&parts.join("."));
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_name_from_str_error_max_label() {
+        let parts = vec!["a".repeat(Name::MAX_LABEL_LENGTH + 1), "com.".to_owned()];
+        let res = Name::from_str(&parts.join("."));
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_name_from_str_error_bad_label_start() {
+        let res = Name::from_str("-example.com.");
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_name_from_str_error_bad_label_end() {
+        let res = Name::from_str("example-.com.");
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_name_from_str_error_bad_label_char() {
+        let res = Name::from_str("exa%mple.com.");
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_name_from_str_error_not_fqdn() {
+        let res = Name::from_str("localhost");
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_name_from_str_success_fqdn() {
+        let name = Name::from_str("example.com.").unwrap();
+        assert!(!name.is_root());
+    }
+
+    #[test]
+    fn test_name_from_str_success_root_empty() {
+        let name = Name::from_str("").unwrap();
+        assert!(name.is_root());
+    }
+
+    #[test]
+    fn test_name_from_str_success_root_dot() {
+        let name = Name::from_str(".").unwrap();
+        assert!(name.is_root());
+    }
+
+    #[test]
+    fn test_name_size_root() {
+        let name = Name::root();
+        assert_eq!(1, name.size());
+    }
+
+    #[test]
+    fn test_name_size_non_root() {
+        let name = Name::from_str("example.com.").unwrap();
+        assert_eq!(13, name.size());
+    }
+
+    #[test]
+    fn test_name_write_network_bytes_root() {
+        let mut cur = Cursor::new(Vec::new());
+        let name = Name::root();
+        name.write_network_bytes(&mut cur).unwrap();
+        let buf = cur.into_inner();
+
+        assert_eq!(vec![0], buf);
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_name_write_network_bytes_not_root() {
+        let mut cur = Cursor::new(Vec::new());
+        let name = Name::from_str("example.com.").unwrap();
+        name.write_network_bytes(&mut cur).unwrap();
+        let buf = cur.into_inner();
+
+        assert_eq!(
+            vec![
+                7,                                // length
+                101, 120, 97, 109, 112, 108, 101, // "example"
+                3,                                // length
+                99, 111, 109,                     // "com"
+                0,                                // root
+            ],
+            buf,
+        );
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_name_read_network_bytes_no_pointer() {
+        let cur = Cursor::new(vec![
+            7,                                // length
+            101, 120, 97, 109, 112, 108, 101, // "example"
+            3,                                // length
+            99, 111, 109,                     // "com"
+            0,                                // root
+        ]);
+
+        let name = Name::read_network_bytes(cur).unwrap();
+        assert_eq!("example.com.", name.to_string());
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_name_read_network_bytes_single_pointer() {
+        let mut cur = Cursor::new(vec![
+            7,                                // length
+            101, 120, 97, 109, 112, 108, 101, // "example"
+            3,                                // length
+            99, 111, 109,                     // "com"
+            0,                                // root
+            3,                                // length
+            119, 119, 119,                    // "www"
+            192, 0,                           // pointer to offset 0
+        ]);
+
+        cur.set_position(13);
+
+        let name = Name::read_network_bytes(cur).unwrap();
+        assert_eq!("www.example.com.", name.to_string());
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_name_read_network_bytes_multiple_pointer() {
+        let mut cur = Cursor::new(vec![
+            7,                                // length
+            101, 120, 97, 109, 112, 108, 101, // "example"
+            3,                                // length
+            99, 111, 109,                     // "com"
+            0,                                // root
+            3,                                // length
+            119, 119, 119,                    // "www"
+            192, 0,                           // pointer to offset 0
+            3,                                // length
+            100, 101, 118,                    // "dev"
+            192, 13,                          // pointer to offset 13, "www"
+        ]);
+
+        cur.set_position(19);
+
+        let name = Name::read_network_bytes(cur).unwrap();
+        assert_eq!("dev.www.example.com.", name.to_string());
+    }
+
+    #[test]
+    fn test_name_read_network_bytes_pointer_loop() {
+        let cur = Cursor::new(vec![
+            192, 2, // pointer to offset 2
+            192, 0, // pointer to offset 0
+        ]);
+
+        let res = Name::read_network_bytes(cur);
+        assert!(res.is_err());
+    }
+}

--- a/mtop-client/src/dns/rdata.rs
+++ b/mtop-client/src/dns/rdata.rs
@@ -1,0 +1,864 @@
+use crate::core::MtopError;
+use crate::dns::core::RecordType;
+use crate::dns::name::Name;
+use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
+use std::fmt;
+use std::fmt::Display;
+use std::io::{Read, Seek};
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum RecordData {
+    A(RecordDataA),
+    NS(RecordDataNS),
+    CNAME(RecordDataCNAME),
+    SOA(RecordDataSOA),
+    TXT(RecordDataTXT),
+    AAAA(RecordDataAAAA),
+    SRV(RecordDataSRV),
+    OPT(RecordDataUnknown),
+    Unknown(RecordDataUnknown),
+}
+
+impl RecordData {
+    pub fn size(&self) -> u16 {
+        match self {
+            Self::A(rd) => rd.size(),
+            Self::NS(rd) => rd.size(),
+            Self::CNAME(rd) => rd.size(),
+            Self::SOA(rd) => rd.size(),
+            Self::TXT(rd) => rd.size(),
+            Self::AAAA(rd) => rd.size(),
+            Self::SRV(rd) => rd.size(),
+            Self::OPT(rd) => rd.size(),
+            Self::Unknown(rd) => rd.size(),
+        }
+    }
+
+    pub fn write_network_bytes<T>(&self, buf: T) -> Result<(), MtopError>
+    where
+        T: WriteBytesExt,
+    {
+        match self {
+            Self::A(rd) => rd.write_network_bytes(buf),
+            Self::NS(rd) => rd.write_network_bytes(buf),
+            Self::CNAME(rd) => rd.write_network_bytes(buf),
+            Self::SOA(rd) => rd.write_network_bytes(buf),
+            Self::TXT(rd) => rd.write_network_bytes(buf),
+            Self::AAAA(rd) => rd.write_network_bytes(buf),
+            Self::SRV(rd) => rd.write_network_bytes(buf),
+            Self::OPT(rd) => rd.write_network_bytes(buf),
+            Self::Unknown(rd) => rd.write_network_bytes(buf),
+        }
+    }
+
+    pub fn read_network_bytes<T>(rtype: RecordType, rdata_len: u16, buf: T) -> Result<Self, MtopError>
+    where
+        T: ReadBytesExt + Seek,
+    {
+        match rtype {
+            RecordType::A => Ok(RecordData::A(RecordDataA::read_network_bytes(buf)?)),
+            RecordType::NS => Ok(RecordData::NS(RecordDataNS::read_network_bytes(buf)?)),
+            RecordType::CNAME => Ok(RecordData::CNAME(RecordDataCNAME::read_network_bytes(buf)?)),
+            RecordType::SOA => Ok(RecordData::SOA(RecordDataSOA::read_network_bytes(buf)?)),
+            RecordType::TXT => Ok(RecordData::TXT(RecordDataTXT::read_network_bytes(rdata_len, buf)?)),
+            RecordType::AAAA => Ok(RecordData::AAAA(RecordDataAAAA::read_network_bytes(buf)?)),
+            RecordType::SRV => Ok(RecordData::SRV(RecordDataSRV::read_network_bytes(buf)?)),
+            RecordType::OPT => Ok(RecordData::OPT(RecordDataUnknown::read_network_bytes(rdata_len, buf)?)),
+            RecordType::Unknown(_) => Ok(RecordData::Unknown(RecordDataUnknown::read_network_bytes(
+                rdata_len, buf,
+            )?)),
+        }
+    }
+}
+
+impl Display for RecordData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RecordData::A(rd) => Display::fmt(rd, f),
+            RecordData::NS(rd) => Display::fmt(rd, f),
+            RecordData::CNAME(rd) => Display::fmt(rd, f),
+            RecordData::SOA(rd) => Display::fmt(rd, f),
+            RecordData::TXT(rd) => Display::fmt(rd, f),
+            RecordData::AAAA(rd) => Display::fmt(rd, f),
+            RecordData::SRV(rd) => Display::fmt(rd, f),
+            RecordData::OPT(rd) => Display::fmt(rd, f),
+            RecordData::Unknown(rd) => Display::fmt(rd, f),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RecordDataA(Ipv4Addr);
+
+impl RecordDataA {
+    pub fn new(addr: Ipv4Addr) -> Self {
+        Self(addr)
+    }
+
+    pub fn addr(&self) -> Ipv4Addr {
+        self.0
+    }
+
+    pub fn size(&self) -> u16 {
+        4
+    }
+
+    pub fn write_network_bytes<T>(&self, mut buf: T) -> Result<(), MtopError>
+    where
+        T: WriteBytesExt,
+    {
+        Ok(buf.write_all(&self.0.octets())?)
+    }
+
+    pub fn read_network_bytes<T>(mut buf: T) -> Result<Self, MtopError>
+    where
+        T: ReadBytesExt + Seek,
+    {
+        let mut bytes = [0_u8; 4];
+        buf.read_exact(&mut bytes)?;
+        Ok(RecordDataA::new(Ipv4Addr::from(bytes)))
+    }
+}
+
+impl Display for RecordDataA {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RecordDataNS(Name);
+
+impl RecordDataNS {
+    pub fn new(name: Name) -> Self {
+        Self(name)
+    }
+
+    pub fn name(&self) -> &Name {
+        &self.0
+    }
+
+    pub fn size(&self) -> u16 {
+        self.0.size()
+    }
+
+    pub fn write_network_bytes<T>(&self, buf: T) -> Result<(), MtopError>
+    where
+        T: WriteBytesExt,
+    {
+        self.0.write_network_bytes(buf)
+    }
+
+    pub fn read_network_bytes<T>(buf: T) -> Result<Self, MtopError>
+    where
+        T: ReadBytesExt + Seek,
+    {
+        Ok(Self::new(Name::read_network_bytes(buf)?))
+    }
+}
+
+impl Display for RecordDataNS {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RecordDataCNAME(Name);
+
+impl RecordDataCNAME {
+    pub fn new(name: Name) -> Self {
+        Self(name)
+    }
+
+    pub fn name(&self) -> &Name {
+        &self.0
+    }
+
+    pub fn size(&self) -> u16 {
+        self.0.size()
+    }
+
+    pub fn write_network_bytes<T>(&self, buf: T) -> Result<(), MtopError>
+    where
+        T: WriteBytesExt,
+    {
+        self.0.write_network_bytes(buf)
+    }
+
+    pub fn read_network_bytes<T>(buf: T) -> Result<Self, MtopError>
+    where
+        T: ReadBytesExt + Seek,
+    {
+        Ok(Self::new(Name::read_network_bytes(buf)?))
+    }
+}
+impl Display for RecordDataCNAME {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RecordDataSOA {
+    mname: Name,
+    rname: Name,
+    serial: u32,
+    refresh: u32,
+    retry: u32,
+    expire: u32,
+    minimum: u32,
+}
+
+impl RecordDataSOA {
+    pub fn new(mname: Name, rname: Name, serial: u32, refresh: u32, retry: u32, expire: u32, minimum: u32) -> Self {
+        Self {
+            mname,
+            rname,
+            serial,
+            refresh,
+            retry,
+            expire,
+            minimum,
+        }
+    }
+
+    pub fn mname(&self) -> &Name {
+        &self.mname
+    }
+
+    pub fn rname(&self) -> &Name {
+        &self.rname
+    }
+
+    pub fn serial(&self) -> u32 {
+        self.serial
+    }
+
+    pub fn refresh(&self) -> u32 {
+        self.refresh
+    }
+
+    pub fn retry(&self) -> u32 {
+        self.retry
+    }
+
+    pub fn expire(&self) -> u32 {
+        self.expire
+    }
+
+    pub fn minimum(&self) -> u32 {
+        self.minimum
+    }
+
+    pub fn size(&self) -> u16 {
+        self.mname.size() + self.rname.size() + (4 * 5)
+    }
+
+    pub fn write_network_bytes<T>(&self, mut buf: T) -> Result<(), MtopError>
+    where
+        T: WriteBytesExt,
+    {
+        self.mname.write_network_bytes(&mut buf)?;
+        self.rname.write_network_bytes(&mut buf)?;
+        buf.write_u32::<NetworkEndian>(self.serial)?;
+        buf.write_u32::<NetworkEndian>(self.refresh)?;
+        buf.write_u32::<NetworkEndian>(self.retry)?;
+        buf.write_u32::<NetworkEndian>(self.expire)?;
+        buf.write_u32::<NetworkEndian>(self.minimum)?;
+        Ok(())
+    }
+
+    pub fn read_network_bytes<T>(mut buf: T) -> Result<Self, MtopError>
+    where
+        T: ReadBytesExt + Seek,
+    {
+        let mname = Name::read_network_bytes(&mut buf)?;
+        let rname = Name::read_network_bytes(&mut buf)?;
+        let serial = buf.read_u32::<NetworkEndian>()?;
+        let refresh = buf.read_u32::<NetworkEndian>()?;
+        let retry = buf.read_u32::<NetworkEndian>()?;
+        let expire = buf.read_u32::<NetworkEndian>()?;
+        let minimum = buf.read_u32::<NetworkEndian>()?;
+
+        Ok(Self::new(mname, rname, serial, refresh, retry, expire, minimum))
+    }
+}
+
+impl Display for RecordDataSOA {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} {} {} {} {} {} {}",
+            self.mname, self.rname, self.serial, self.refresh, self.retry, self.expire, self.minimum
+        )
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RecordDataTXT(Vec<Vec<u8>>);
+
+impl RecordDataTXT {
+    const MAX_LENGTH: usize = 255;
+    const MAX_TOTAL_SIZE: usize = 65535;
+
+    pub fn new<I, B>(items: I) -> Result<Self, MtopError>
+    where
+        I: IntoIterator<Item = B>,
+        B: Into<Vec<u8>>,
+    {
+        let mut segments = Vec::new();
+        let mut total = 0;
+
+        for txt in items {
+            let bytes = txt.into();
+            if bytes.len() > Self::MAX_LENGTH {
+                return Err(MtopError::runtime(format!(
+                    "TXT record segment too long; {} bytes, max {} bytes",
+                    bytes.len(),
+                    Self::MAX_LENGTH
+                )));
+            }
+
+            total += bytes.len();
+            if total > Self::MAX_TOTAL_SIZE {
+                return Err(MtopError::runtime(format!(
+                    "TXT record too long; {} bytes, max {} bytes",
+                    total,
+                    Self::MAX_TOTAL_SIZE
+                )));
+            }
+
+            segments.push(bytes);
+        }
+
+        Ok(Self(segments))
+    }
+
+    pub fn bytes(&self) -> &Vec<Vec<u8>> {
+        &self.0
+    }
+
+    pub fn size(&self) -> u16 {
+        (self.0.iter().map(|v| v.len()).sum::<usize>() + self.0.len()) as u16
+    }
+
+    pub fn write_network_bytes<T>(&self, mut buf: T) -> Result<(), MtopError>
+    where
+        T: WriteBytesExt,
+    {
+        for txt in self.0.iter() {
+            buf.write_u8(txt.len() as u8)?;
+            buf.write_all(txt)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn read_network_bytes<T>(rdata_len: u16, mut buf: T) -> Result<Self, MtopError>
+    where
+        T: ReadBytesExt + Seek,
+    {
+        let mut all = Vec::new();
+
+        let mut consumed = 0;
+        while consumed < rdata_len {
+            let len = buf.read_u8()?;
+            if len as u16 + consumed > rdata_len {
+                return Err(MtopError::runtime(format!(
+                    "text for RecordDataTXT exceeds rdata size; len: {}, consumed: {}, rdata: {}",
+                    len, consumed, rdata_len
+                )));
+            }
+
+            let mut txt = Vec::new();
+            let mut handle = buf.take(len as u64);
+            let n = handle.read_to_end(&mut txt)?;
+            if n != len as usize {
+                return Err(MtopError::runtime(format!(
+                    "short read for RecordDataTXT text; expected {}, got {}",
+                    len, n
+                )));
+            }
+
+            all.push(txt);
+            consumed += n as u16 + 1;
+            buf = handle.into_inner();
+        }
+
+        Self::new(all)
+    }
+}
+
+impl Display for RecordDataTXT {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for txt in self.0.iter() {
+            // We're trying to display the record so make an attempt at converting to
+            // a string but don't return an error or panic if there's invalid UTF-8. We
+            // also escape any double quotes within the string since we use those to
+            // delimit the string.
+            write!(f, "\"{}\"", String::from_utf8_lossy(txt).replace('\"', "\\\""))?
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RecordDataAAAA(Ipv6Addr);
+
+impl RecordDataAAAA {
+    pub fn new(addr: Ipv6Addr) -> Self {
+        Self(addr)
+    }
+
+    pub fn addr(&self) -> Ipv6Addr {
+        self.0
+    }
+
+    pub fn size(&self) -> u16 {
+        16
+    }
+
+    pub fn write_network_bytes<T>(&self, mut buf: T) -> Result<(), MtopError>
+    where
+        T: WriteBytesExt,
+    {
+        Ok(buf.write_all(&self.0.octets())?)
+    }
+
+    pub fn read_network_bytes<T>(mut buf: T) -> Result<Self, MtopError>
+    where
+        T: ReadBytesExt + Seek,
+    {
+        let mut bytes = [0_u8; 16];
+        buf.read_exact(&mut bytes)?;
+        Ok(RecordDataAAAA::new(Ipv6Addr::from(bytes)))
+    }
+}
+
+impl Display for RecordDataAAAA {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RecordDataSRV {
+    priority: u16,
+    weight: u16,
+    port: u16,
+    target: Name,
+}
+
+impl RecordDataSRV {
+    pub fn new(priority: u16, weight: u16, port: u16, target: Name) -> Self {
+        Self {
+            priority,
+            weight,
+            port,
+            target,
+        }
+    }
+
+    pub fn priority(&self) -> u16 {
+        self.priority
+    }
+
+    pub fn weight(&self) -> u16 {
+        self.weight
+    }
+
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    pub fn target(&self) -> &Name {
+        &self.target
+    }
+
+    pub fn size(&self) -> u16 {
+        (2 * 3) + self.target.size()
+    }
+
+    pub fn write_network_bytes<T>(&self, mut buf: T) -> Result<(), MtopError>
+    where
+        T: WriteBytesExt,
+    {
+        buf.write_u16::<NetworkEndian>(self.priority)?;
+        buf.write_u16::<NetworkEndian>(self.weight)?;
+        buf.write_u16::<NetworkEndian>(self.port)?;
+        self.target.write_network_bytes(buf)
+    }
+
+    pub fn read_network_bytes<T>(mut buf: T) -> Result<Self, MtopError>
+    where
+        T: ReadBytesExt + Seek,
+    {
+        let priority = buf.read_u16::<NetworkEndian>()?;
+        let weight = buf.read_u16::<NetworkEndian>()?;
+        let port = buf.read_u16::<NetworkEndian>()?;
+        let target = Name::read_network_bytes(buf)?;
+
+        Ok(Self::new(priority, weight, port, target))
+    }
+}
+
+impl Display for RecordDataSRV {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} {} {} {}", self.priority, self.weight, self.port, self.target)
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RecordDataUnknown(Vec<u8>);
+
+impl RecordDataUnknown {
+    const MAX_SIZE: usize = 65535;
+
+    pub fn new(bytes: Vec<u8>) -> Result<Self, MtopError> {
+        if bytes.len() > Self::MAX_SIZE {
+            Err(MtopError::runtime(format!(
+                "record data too long; {} bytes, max {} bytes",
+                bytes.len(),
+                Self::MAX_SIZE
+            )))
+        } else {
+            Ok(Self(bytes))
+        }
+    }
+
+    pub fn size(&self) -> u16 {
+        self.0.len() as u16
+    }
+
+    pub fn write_network_bytes<T>(&self, mut buf: T) -> Result<(), MtopError>
+    where
+        T: WriteBytesExt,
+    {
+        buf.write_all(&self.0)?;
+        Ok(())
+    }
+
+    pub fn read_network_bytes<T>(rdata_len: u16, buf: T) -> Result<Self, MtopError>
+    where
+        T: ReadBytesExt + Seek,
+    {
+        let mut bytes = Vec::new();
+        let n = buf.take(rdata_len as u64).read_to_end(&mut bytes)?;
+        if n != rdata_len as usize {
+            return Err(MtopError::runtime(format!(
+                "short read for RecordDataUnknown; expected {} got {}",
+                rdata_len, n
+            )));
+        }
+
+        Self::new(bytes)
+    }
+}
+
+impl Display for RecordDataUnknown {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[unknown]")
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{
+        RecordDataA, RecordDataAAAA, RecordDataCNAME, RecordDataNS, RecordDataSOA, RecordDataSRV, RecordDataTXT,
+    };
+    use crate::dns::name::Name;
+    use std::io::Cursor;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+    use std::str::FromStr;
+
+    #[test]
+    fn test_record_data_a_write_network_bytes() {
+        let rdata = RecordDataA::new(Ipv4Addr::new(127, 0, 0, 1));
+
+        let mut cur = Cursor::new(Vec::new());
+        rdata.write_network_bytes(&mut cur).unwrap();
+        let buf = cur.into_inner();
+
+        assert_eq!(vec![127, 0, 0, 1], buf);
+    }
+    #[test]
+    fn test_record_data_a_read_network_bytes() {
+        let cur = Cursor::new(vec![127, 0, 0, 53]);
+        let rdata = RecordDataA::read_network_bytes(cur).unwrap();
+
+        assert_eq!(Ipv4Addr::new(127, 0, 0, 53), rdata.addr());
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_record_data_ns_write_network_bytes() {
+        let name = Name::from_str("ns.example.com.").unwrap();
+        let ns = RecordDataNS::new(name);
+
+        let mut cur = Cursor::new(Vec::new());
+        ns.write_network_bytes(&mut cur).unwrap();
+        let buf = cur.into_inner();
+
+        assert_eq!(
+            vec![
+                2,                                // length
+                110, 115,                         // "ns"
+                7,                                // length
+                101, 120, 97, 109, 112, 108, 101, // "example"
+                3,                                // length
+                99, 111, 109,                     // "com"
+                0,                                // root
+            ],
+            buf,
+        );
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_record_data_ns_read_network_bytes() {
+        let cur = Cursor::new(vec![
+            2,                                // length
+            110, 115,                         // "ns"
+            7,                                // length
+            101, 120, 97, 109, 112, 108, 101, // "example"
+            3,                                // length
+            99, 111, 109,                     // "com"
+            0,                                // root
+        ]);
+
+        let rdata = RecordDataNS::read_network_bytes(cur).unwrap();
+        assert_eq!("ns.example.com.", rdata.name().to_string());
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_record_data_cname_write_network_bytes() {
+        let name = Name::from_str("www.example.com.").unwrap();
+        let ns = RecordDataCNAME::new(name);
+
+        let mut cur = Cursor::new(Vec::new());
+        ns.write_network_bytes(&mut cur).unwrap();
+        let buf = cur.into_inner();
+
+        assert_eq!(
+            vec![
+                3,                                // length
+                119, 119, 119,                    // "www"
+                7,                                // length
+                101, 120, 97, 109, 112, 108, 101, // "example"
+                3,                                // length
+                99, 111, 109,                     // "com"
+                0,                                // root
+            ],
+            buf,
+        );
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_record_data_cname_read_network_bytes() {
+        let cur = Cursor::new(vec![
+            3,                                // length
+            119, 119, 119,                    // "www"
+            7,                                // length
+            101, 120, 97, 109, 112, 108, 101, // "example"
+            3,                                // length
+            99, 111, 109,                     // "com"
+            0,                                // root
+        ]);
+
+        let rdata = RecordDataCNAME::read_network_bytes(cur).unwrap();
+        assert_eq!("www.example.com.", rdata.name().to_string());
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_record_data_soa_write_network_bytes() {
+        let mname = Name::from_str("m.example.com.").unwrap();
+        let rname = Name::from_str("r.example.com.").unwrap();
+        let serial = 123456790;
+        let refresh = 3000;
+        let retry = 300;
+        let expire = 3600;
+        let minimum = 600;
+
+        let soa = RecordDataSOA::new(mname, rname, serial, refresh, retry, expire, minimum);
+        let mut cur = Cursor::new(Vec::new());
+        soa.write_network_bytes(&mut cur).unwrap();
+        let buf = cur.into_inner();
+
+        assert_eq!(
+             vec![
+                1,                                // length
+                109,                              // "m"
+                7,                                // length
+                101, 120, 97, 109, 112, 108, 101, // "example"
+                3,                                // length
+                99, 111, 109,                     // "com"
+                0,                                // root
+                1,                                // length
+                114,                              // "r"
+                7,                                // length
+                101, 120, 97, 109, 112, 108, 101, // "example"
+                3,                                // length
+                99, 111, 109,                     // "com"
+                0,                                // root
+                7, 91, 205, 22,                   // serial
+                0, 0, 11, 184,                    // refresh
+                0, 0, 1, 44,                      // retry
+                0, 0, 14, 16,                     // expire
+                0, 0, 2, 88                       // minimum
+             ],
+             buf,
+         );
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_record_data_soa_read_network_bytes() {
+        let cur = Cursor::new(vec![
+            1,                                // length
+            109,                              // "m"
+            7,                                // length
+            101, 120, 97, 109, 112, 108, 101, // "example"
+            3,                                // length
+            99, 111, 109,                     // "com"
+            0,                                // root
+            1,                                // length
+            114,                              // "r"
+            7,                                // length
+            101, 120, 97, 109, 112, 108, 101, // "example"
+            3,                                // length
+            99, 111, 109,                     // "com"
+            0,                                // root
+            7, 91, 205, 22,                   // serial
+            0, 0, 11, 184,                    // refresh
+            0, 0, 1, 44,                      // retry
+            0, 0, 14, 16,                     // expire
+            0, 0, 2, 88                       // minimum
+        ]);
+
+        let rdata = RecordDataSOA::read_network_bytes(cur).unwrap();
+        assert_eq!("m.example.com.", rdata.mname().to_string());
+        assert_eq!("r.example.com.", rdata.rname().to_string());
+        assert_eq!(123456790, rdata.serial());
+        assert_eq!(3000, rdata.refresh());
+        assert_eq!(300, rdata.retry());
+        assert_eq!(3600, rdata.expire());
+        assert_eq!(600, rdata.minimum());
+    }
+
+    #[test]
+    fn test_record_data_txt_size() {
+        let txt = RecordDataTXT::new(vec!["id=hello", "user=world"]).unwrap();
+        assert_eq!(20, txt.size());
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_record_data_txt_write_network_bytes() {
+        let txt = RecordDataTXT::new(vec!["id=hello", "user=world"]).unwrap();
+        let mut cur = Cursor::new(Vec::new());
+        txt.write_network_bytes(&mut cur).unwrap();
+        let buf = cur.into_inner();
+
+        assert_eq!(
+            vec![
+                8,                                               // length
+                105, 100, 61, 104, 101, 108, 108, 111,           // id=hello
+                10,                                              // length
+                117, 115, 101, 114, 61, 119, 111, 114, 108, 100, // user=world
+            ],
+            buf,
+        )
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_record_data_txt_read_network_bytes() {
+        let bytes = vec![
+            8,                                               // length
+            105, 100, 61, 104, 101, 108, 108, 111,           // id=hello
+            10,                                              // length
+            117, 115, 101, 114, 61, 119, 111, 114, 108, 100, // user=world
+        ];
+        let bytes_len = bytes.len() as u16;
+        let cur = Cursor::new(bytes);
+
+        let rdata = RecordDataTXT::read_network_bytes(bytes_len, cur).unwrap();
+        let contents = rdata.bytes();
+        assert_eq!("id=hello".as_bytes(), contents[0]);
+        assert_eq!("user=world".as_bytes(), contents[1]);
+    }
+
+    #[test]
+    fn test_record_data_aaaa_write_network_bytes() {
+        let addr = Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1);
+        let rdata = RecordDataAAAA::new(addr);
+
+        let mut cur = Cursor::new(Vec::new());
+        rdata.write_network_bytes(&mut cur).unwrap();
+        let buf = cur.into_inner();
+
+        assert_eq!(vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1], buf);
+    }
+
+    #[test]
+    fn test_record_data_aaaa_read_network_bytes() {
+        let cur = Cursor::new(vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+        let rdata = RecordDataAAAA::read_network_bytes(cur).unwrap();
+
+        assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), rdata.addr());
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_record_data_srv_write_network_bytes() {
+        let srv = RecordDataSRV::new(100, 20, 11211, Name::from_str("_cache.example.com.").unwrap());
+        let mut cur = Cursor::new(Vec::new());
+        srv.write_network_bytes(&mut cur).unwrap();
+        let buf = cur.into_inner();
+
+        assert_eq!(
+            vec![
+                0, 100,                           // priority
+                0, 20,                            // weight
+                43, 203,                          // port
+                6,                                // length
+                95, 99, 97, 99, 104, 101,         // "_cache"
+                7,                                // length
+                101, 120, 97, 109, 112, 108, 101, // "example"
+                3,                                // length
+                99, 111, 109,                     // "com"
+                0,                                // root
+            ],
+            buf,
+        )
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_record_data_srv_read_network_bytes() {
+        let cur = Cursor::new(vec![
+            0, 100,                           // priority
+            0, 20,                            // weight
+            43, 203,                          // port
+            6,                                // length
+            95, 99, 97, 99, 104, 101,         // "_cache"
+            7,                                // length
+            101, 120, 97, 109, 112, 108, 101, // "example"
+            3,                                // length
+            99, 111, 109,                     // "com"
+            0,                                // root
+        ]);
+
+        let rdata = RecordDataSRV::read_network_bytes(cur).unwrap();
+        assert_eq!(100, rdata.priority());
+        assert_eq!(20, rdata.weight());
+        assert_eq!(11211, rdata.port());
+        assert_eq!("_cache.example.com.", rdata.target().to_string());
+    }
+}

--- a/mtop-client/src/lib.rs
+++ b/mtop-client/src/lib.rs
@@ -3,6 +3,8 @@ mod core;
 mod pool;
 mod timeout;
 
+pub mod dns;
+
 pub use crate::client::{MemcachedClient, SelectorRendezvous, ServersResponse, ValuesResponse};
 pub use crate::core::{
     ErrorKind, Key, Memcached, Meta, MtopError, ProtocolError, ProtocolErrorKind, Slab, SlabItem, SlabItems, Slabs,

--- a/mtop/src/bin/dns.rs
+++ b/mtop/src/bin/dns.rs
@@ -1,0 +1,275 @@
+use clap::{Args, Parser, Subcommand};
+use mtop_client::dns::{Flags, Message, Name, Question, Record, RecordClass, RecordType};
+use mtop_client::MtopError;
+use mtop_client::Timeout;
+use std::fmt::Write;
+use std::io::Cursor;
+use std::process::ExitCode;
+use std::str::FromStr;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::ToSocketAddrs;
+use tokio::net::UdpSocket;
+use tracing::Level;
+
+const DEFAULT_HOST: &str = "127.0.0.1:53";
+const DEFAULT_TIMEOUT_SECS: u64 = 5;
+const DEFAULT_RECORD_TYPE: RecordType = RecordType::A;
+const DEFAULT_RECORD_CLASS: RecordClass = RecordClass::INET;
+
+/// dns: Make DNS queries or read/write binary format DNS messages
+#[derive(Debug, Parser)]
+#[command(name = "dns", version = clap::crate_version!())]
+struct DnsConfig {
+    #[command(subcommand)]
+    mode: Action,
+}
+
+#[derive(Debug, Subcommand)]
+enum Action {
+    Query(QueryCommand),
+    Read(ReadCommand),
+    Write(WriteCommand),
+}
+
+/// Perform a DNS query and display the result as dig-like text output.
+#[derive(Debug, Args)]
+struct QueryCommand {
+    /// Server to make the request to in the form 'hostname:port'
+    #[arg(long, default_value_t = DEFAULT_HOST.to_owned())]
+    server: String,
+
+    /// Timeout for making requests to a DNS server, in seconds.
+    #[arg(long, default_value_t = DEFAULT_TIMEOUT_SECS)]
+    timeout_secs: u64,
+
+    /// Output query results in raw binary format instead of human-readable
+    /// text. NOTE, this may break your terminal and so should probably be piped
+    /// to a file.
+    #[arg(long, default_value_t = false)]
+    raw: bool,
+
+    /// Type of record to request. Supported: A, AAAA, CNAME, NS, SOA, SRV, TXT.
+    #[arg(long, default_value_t = DEFAULT_RECORD_TYPE)]
+    rtype: RecordType,
+
+    /// Class of record to request. Supported: INET, CHAOS, HESIOD, NONE, ANY.
+    #[arg(long, default_value_t = DEFAULT_RECORD_CLASS)]
+    rclass: RecordClass,
+
+    /// Domain name to lookup.
+    #[arg(required = true)]
+    name: String,
+}
+
+/// Read a binary format DNS message from standard input and display it as dig-like text output.
+#[derive(Debug, Args)]
+struct ReadCommand {}
+
+/// Write a binary format DNS message to standard output.
+#[derive(Debug, Args)]
+struct WriteCommand {
+    /// Type of record to request. Supported: A, AAAA, CNAME, NS, SOA, SRV, TXT.
+    #[arg(long, default_value_t = DEFAULT_RECORD_TYPE)]
+    rtype: RecordType,
+
+    /// Class of record to request. Supported: INET, CHAOS, HESIOD, NONE, ANY.
+    #[arg(long, default_value_t = DEFAULT_RECORD_CLASS)]
+    rclass: RecordClass,
+
+    /// Domain name to lookup.
+    #[arg(required = true)]
+    name: String,
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    let opts = DnsConfig::parse();
+
+    let console_subscriber = mtop::tracing::console_subscriber(Level::DEBUG).expect("failed to setup console logging");
+    tracing::subscriber::set_global_default(console_subscriber).expect("failed to initialize console logging");
+
+    match &opts.mode {
+        Action::Query(cmd) => run_query(cmd).await,
+        Action::Read(cmd) => run_read(cmd).await,
+        Action::Write(cmd) => run_write(cmd).await,
+    }
+}
+
+async fn connect<A>(server: A) -> Result<UdpSocket, MtopError>
+where
+    A: ToSocketAddrs,
+{
+    let socket = UdpSocket::bind("0.0.0.0:0").await?;
+    socket.connect(server).await?;
+    Ok(socket)
+}
+
+async fn run_query(cmd: &QueryCommand) -> ExitCode {
+    let timeout = Duration::from_secs(cmd.timeout_secs);
+    let socket = match connect(&cmd.server).timeout(timeout, "socket.connect").await {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!(message = "unable to open UDP socket", "server" = cmd.server, err = %e);
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let name = match Name::from_str(&cmd.name) {
+        Ok(n) => n,
+        Err(e) => {
+            tracing::error!(message = "invalid name supplied", name = cmd.name, err = %e);
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let id = mtop_client::dns::id();
+    let msg = Message::new(id, Flags::default().set_query().set_recursion_desired())
+        .add_question(Question::new(name, cmd.rtype).set_qclass(cmd.rclass));
+
+    if let Err(e) = mtop_client::dns::send(&socket, &msg)
+        .timeout(timeout, "socket.send")
+        .await
+    {
+        tracing::error!(message = "unable to send message", "server" = cmd.server, err = %e);
+        return ExitCode::FAILURE;
+    }
+
+    let response = match mtop_client::dns::recv(&socket, id)
+        .timeout(timeout, "socket.recv")
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!(message = "unable to receive message", "server" = cmd.server, err = %e);
+            return ExitCode::FAILURE;
+        }
+    };
+
+    if cmd.raw {
+        write_binary_message(&response).await
+    } else {
+        write_text_message(&response).await
+    }
+}
+
+async fn run_read(_: &ReadCommand) -> ExitCode {
+    let mut buf = Vec::new();
+    let mut input = tokio::io::stdin();
+
+    let n = match input.read_to_end(&mut buf).await {
+        Ok(n) => n,
+        Err(e) => {
+            tracing::error!(message = "unable to read message from stdin", err = %e);
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let cur = Cursor::new(&buf[0..n]);
+    let msg = match Message::read_network_bytes(cur) {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::error!(message = "malformed message", err = %e);
+            return ExitCode::FAILURE;
+        }
+    };
+
+    write_text_message(&msg).await;
+    ExitCode::SUCCESS
+}
+
+async fn run_write(cmd: &WriteCommand) -> ExitCode {
+    let name = match Name::from_str(&cmd.name) {
+        Ok(n) => n,
+        Err(e) => {
+            tracing::error!(message = "invalid name supplied", name = cmd.name, err = %e);
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let id = rand::random();
+    let msg = Message::new(id, Flags::default().set_query().set_recursion_desired())
+        .add_question(Question::new(name, cmd.rtype).set_qclass(cmd.rclass));
+
+    write_binary_message(&msg).await
+}
+
+async fn write_binary_message(msg: &Message) -> ExitCode {
+    let mut buf = Vec::new();
+    if let Err(e) = msg.write_network_bytes(&mut buf) {
+        tracing::error!(message = "unable to encode message to wire format", err = %e);
+        return ExitCode::FAILURE;
+    }
+
+    let mut out = tokio::io::stdout();
+    if let Err(e) = out.write_all(&buf).await {
+        tracing::error!(message = "unable to write wire encoded message to stdout", err = %e);
+        return ExitCode::FAILURE;
+    }
+
+    ExitCode::SUCCESS
+}
+
+async fn write_text_message(msg: &Message) -> ExitCode {
+    let mut buf = String::new();
+    format_header(&mut buf, msg);
+    format_question(&mut buf, msg.questions());
+    format_answer(&mut buf, msg.answers());
+    format_authority(&mut buf, msg.authority());
+    format_extra(&mut buf, msg.extra());
+
+    let mut out = tokio::io::stdout();
+    if let Err(e) = out.write_all(buf.as_bytes()).await {
+        tracing::error!(message = "unable to write human readable message to stdout", err = %e);
+        return ExitCode::FAILURE;
+    }
+
+    ExitCode::SUCCESS
+}
+
+fn format_header(buf: &mut String, msg: &Message) {
+    let _ = writeln!(
+        buf,
+        ";; >>HEADER<< opcode: {:?}, status: {:?}, id: {}",
+        msg.flags().get_op_code(),
+        msg.flags().get_response_code(),
+        msg.id()
+    );
+    let _ = writeln!(buf, ";; flags: {:?}", msg.flags());
+}
+
+fn format_question(buf: &mut String, questions: &[Question]) {
+    let _ = writeln!(buf, ";; QUESTION SECTION:");
+    for q in questions {
+        let _ = writeln!(buf, "; {}\t\t\t{}\t{}", q.name(), q.qclass(), q.qtype());
+    }
+}
+
+fn format_authority(buf: &mut String, records: &[Record]) {
+    let _ = writeln!(buf, ";; AUTHORITY SECTION:");
+    format_records(buf, records);
+}
+
+fn format_answer(buf: &mut String, records: &[Record]) {
+    let _ = writeln!(buf, ";; ANSWER SECTION:");
+    format_records(buf, records);
+}
+
+fn format_extra(buf: &mut String, records: &[Record]) {
+    let _ = writeln!(buf, ";; ADDITIONAL SECTION:");
+    format_records(buf, records);
+}
+
+fn format_records(buf: &mut String, records: &[Record]) {
+    for r in records {
+        let _ = writeln!(
+            buf,
+            "{}\t\t{}\t{}\t{}\t{}",
+            r.name(),
+            r.ttl(),
+            r.rclass(),
+            r.rtype(),
+            r.rdata()
+        );
+    }
+}


### PR DESCRIPTION
This change creates a very basic DNS client capable of performing A, AAAA, CNAME, NS, SOA, TXT, and SRV types of queries. This is the first step in supporting DNS lookup of SRV records for service discovery in `mtop` and `mc`. It also adds a `dns` executable capable of making queries and parsing binary DNS messages.

This client has undergone very little testing and should be considered both experimental and internal to mtop.

See #107