### PR TITLE
Read DNS settings from a resolv.conf file

### DIFF
--- a/mtop-client/src/core.rs
+++ b/mtop-client/src/core.rs
@@ -206,10 +206,7 @@ impl TryFrom<&HashMap<String, String>> for Slabs {
         // $active_slabs + 1.
         let mut ids = BTreeSet::new();
         for k in value.keys() {
-            let key_id: Option<u64> = k
-                .split_once(':')
-                .map(|(raw, _rest)| raw)
-                .and_then(|raw| raw.parse().ok());
+            let key_id: Option<u64> = k.split_once(':').map(|(raw, _rest)| raw).and_then(|raw| raw.parse().ok());
 
             if let Some(id) = key_id {
                 ids.insert(id);
@@ -1287,9 +1284,7 @@ mod test {
     macro_rules! test_store_command_success {
         ($method:ident, $verb:expr) => {
             let (mut rx, mut client) = client!("STORED\r\n");
-            let res = client
-                .$method(&Key::one("test").unwrap(), 0, 300, "val".as_bytes())
-                .await;
+            let res = client.$method(&Key::one("test").unwrap(), 0, 300, "val".as_bytes()).await;
 
             assert!(res.is_ok());
             let bytes = rx.recv().await.unwrap();
@@ -1301,9 +1296,7 @@ mod test {
     macro_rules! test_store_command_error {
         ($method:ident, $verb:expr) => {
             let (mut rx, mut client) = client!("NOT_STORED\r\n");
-            let res = client
-                .$method(&Key::one("test").unwrap(), 0, 300, "val".as_bytes())
-                .await;
+            let res = client.$method(&Key::one("test").unwrap(), 0, 300, "val".as_bytes()).await;
 
             assert!(res.is_err());
             let err = res.unwrap_err();

--- a/mtop-client/src/dns/message.rs
+++ b/mtop-client/src/dns/message.rs
@@ -240,18 +240,12 @@ impl Header {
 pub struct Flags(u16);
 
 impl Flags {
-    const MASK_QR: u16 = 0b1000_0000_0000_0000;
-    // query / response
-    const MASK_OP: u16 = 0b0111_1000_0000_0000;
-    // 4 bits, op code
-    const MASK_AA: u16 = 0b0000_0100_0000_0000;
-    // authoritative answer
-    const MASK_TC: u16 = 0b0000_0010_0000_0000;
-    // truncated
-    const MASK_RD: u16 = 0b0000_0001_0000_0000;
-    // recursion desired
-    const MASK_RA: u16 = 0b0000_0000_1000_0000;
-    // recursion available
+    const MASK_QR: u16 = 0b1000_0000_0000_0000; // query / response
+    const MASK_OP: u16 = 0b0111_1000_0000_0000; // 4 bits, op code
+    const MASK_AA: u16 = 0b0000_0100_0000_0000; // authoritative answer
+    const MASK_TC: u16 = 0b0000_0010_0000_0000; // truncated
+    const MASK_RD: u16 = 0b0000_0001_0000_0000; // recursion desired
+    const MASK_RA: u16 = 0b0000_0000_1000_0000; // recursion available
     const MASK_RC: u16 = 0b0000_0000_0000_1111; // 4 bits, response code
 
     const OFFSET_QR: usize = 15;

--- a/mtop-client/src/dns/mod.rs
+++ b/mtop-client/src/dns/mod.rs
@@ -3,6 +3,7 @@ mod core;
 mod message;
 mod name;
 mod rdata;
+mod resolv;
 
 pub use crate::dns::client::DnsClient;
 pub use crate::dns::core::{RecordClass, RecordType};
@@ -12,3 +13,4 @@ pub use crate::dns::rdata::{
     RecordData, RecordDataA, RecordDataAAAA, RecordDataCNAME, RecordDataNS, RecordDataSOA, RecordDataSRV,
     RecordDataTXT, RecordDataUnknown,
 };
+pub use resolv::{config, ResolvConf, ResolvConfOptions};

--- a/mtop-client/src/dns/resolv.rs
+++ b/mtop-client/src/dns/resolv.rs
@@ -1,0 +1,345 @@
+use crate::core::MtopError;
+use std::fmt::Debug;
+use std::net::{IpAddr, SocketAddr};
+use std::str::FromStr;
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
+
+const DEFAULT_PORT: u16 = 53;
+const MAX_NAMESERVERS: usize = 3;
+
+/// Configuration for a DNS client based on a parsed resolv.conf file.
+///
+/// Note that only the `nameserver` setting and a few `option`s are supported.
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
+pub struct ResolvConf {
+    pub nameservers: Vec<SocketAddr>,
+    pub options: ResolvConfOptions,
+}
+
+/// Options to change the behavior of a DNS client based on a resolv.conf file.
+///
+/// Note that only a subset of options are supported.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ResolvConfOptions {
+    pub timeout: Duration,
+    pub attempts: u8,
+    pub rotate: bool,
+}
+
+impl Default for ResolvConfOptions {
+    fn default() -> Self {
+        // Defaults picked based on `man 5 resolv.conf`
+        Self {
+            timeout: Duration::from_secs(5),
+            attempts: 2,
+            rotate: false,
+        }
+    }
+}
+
+/// Read settings for a DNS client from a resolv.conf configuration file.
+pub async fn config<R>(read: R) -> Result<ResolvConf, MtopError>
+where
+    R: AsyncRead + Send + Sync + Unpin + 'static,
+{
+    let mut lines = BufReader::new(read).lines();
+    let mut conf = ResolvConf::default();
+
+    while let Some(line) = lines.next_line().await? {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        let mut parts = line.split_whitespace();
+        let key = match parts.next() {
+            Some(k) => k,
+            None => {
+                tracing::debug!(message = "skipping malformed resolv.conf line", line = line);
+                continue;
+            }
+        };
+
+        match Token::get(key) {
+            Some(Token::NameServer) => {
+                if conf.nameservers.len() < MAX_NAMESERVERS {
+                    conf.nameservers.push(parse_nameserver(line, parts)?);
+                }
+            }
+            Some(Token::Options) => {
+                for opt in parse_options(parts) {
+                    match opt {
+                        OptionsToken::Timeout(t) => {
+                            conf.options.timeout = Duration::from_secs(u64::from(t));
+                        }
+                        OptionsToken::Attempts(n) => {
+                            conf.options.attempts = n;
+                        }
+                        OptionsToken::Rotate => {
+                            conf.options.rotate = true;
+                        }
+                    }
+                }
+            }
+            None => {
+                tracing::debug!(
+                    message = "skipping unknown resolv.conf setting",
+                    setting = key,
+                    line = line
+                );
+                continue;
+            }
+        }
+    }
+
+    Ok(conf)
+}
+
+/// Parse a single nameserver IP address, adding a default port of 53, from a `nameserver`
+/// line in a resolv.conf file, returning an error if the address is malformed.
+fn parse_nameserver<'a>(line: &str, mut parts: impl Iterator<Item = &'a str>) -> Result<SocketAddr, MtopError> {
+    if let Some(part) = parts.next() {
+        part.parse::<IpAddr>()
+            .map(|ip| (ip, DEFAULT_PORT).into())
+            .map_err(|e| MtopError::configuration_cause(format!("malformed nameserver address '{}'", part), e))
+    } else {
+        Err(MtopError::configuration(format!(
+            "malformed nameserver configuration '{}'",
+            line
+        )))
+    }
+}
+
+/// Parse one or more options from an `option` line in a resolv.conf file, ignoring any
+/// malformed or unsupported options.
+fn parse_options<'a>(parts: impl Iterator<Item = &'a str>) -> Vec<OptionsToken> {
+    let mut out = Vec::new();
+
+    for part in parts {
+        let opt = match part.parse() {
+            Ok(o) => o,
+            Err(e) => {
+                tracing::debug!(message = "skipping unknown resolv.conf option", option = part, err = %e);
+                continue;
+            }
+        };
+
+        out.push(opt);
+    }
+    out
+}
+
+/// Top-level configuration setting in a resolv.conf file.
+///
+/// Note that only a subset of all possible settings are supported.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+enum Token {
+    NameServer,
+    Options,
+}
+
+impl Token {
+    fn get(s: &str) -> Option<Self> {
+        match s {
+            "nameserver" => Some(Self::NameServer),
+            "options" => Some(Self::Options),
+            _ => None,
+        }
+    }
+}
+
+/// Keyword or key-value pair associated with an option token.
+///
+/// Note that only a subset of all possible options are supported.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+enum OptionsToken {
+    Timeout(u8),
+    Attempts(u8),
+    Rotate,
+}
+
+impl OptionsToken {
+    const MAX_TIMEOUT: u8 = 30;
+    const MAX_ATTEMPTS: u8 = 5;
+
+    fn parse(line: &str, val: &str, max: u8) -> Result<u8, MtopError> {
+        let n = val
+            .parse()
+            .map_err(|e| MtopError::configuration_cause(format!("unable to parse {} value '{}'", line, val), e))?;
+        if n > max {
+            Ok(max)
+        } else {
+            Ok(n)
+        }
+    }
+}
+
+impl FromStr for OptionsToken {
+    type Err = MtopError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == "rotate" {
+            Ok(Self::Rotate)
+        } else {
+            match s.split_once(':') {
+                Some(("timeout", v)) => Ok(Self::Timeout(Self::parse(s, v, Self::MAX_TIMEOUT)?)),
+                Some(("attempts", v)) => Ok(Self::Attempts(Self::parse(s, v, Self::MAX_ATTEMPTS)?)),
+                _ => Err(MtopError::configuration(format!("unknown option {}", s))),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{config, OptionsToken, Token};
+    use crate::core::ErrorKind;
+    use crate::dns::{ResolvConf, ResolvConfOptions};
+    use std::io::{Cursor, Error as IOError, ErrorKind as IOErrorKind};
+    use std::pin::Pin;
+    use std::str::FromStr;
+    use std::task::{Context, Poll};
+    use std::time::Duration;
+    use tokio::io::{AsyncRead, ReadBuf};
+
+    #[test]
+    fn test_configuration() {
+        assert_eq!(Some(Token::NameServer), Token::get("nameserver"));
+        assert_eq!(Some(Token::Options), Token::get("options"));
+        assert_eq!(None, Token::get("invalid"));
+    }
+
+    #[test]
+    fn test_configuration_option_success() {
+        assert_eq!(OptionsToken::Rotate, OptionsToken::from_str("rotate").unwrap());
+        assert_eq!(OptionsToken::Timeout(3), OptionsToken::from_str("timeout:3").unwrap());
+        assert_eq!(OptionsToken::Attempts(4), OptionsToken::from_str("attempts:4").unwrap());
+    }
+
+    #[test]
+    fn test_configuration_option_limits() {
+        assert_eq!(OptionsToken::Timeout(30), OptionsToken::from_str("timeout:35").unwrap());
+        assert_eq!(
+            OptionsToken::Attempts(5),
+            OptionsToken::from_str("attempts:10").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_configuration_option_error() {
+        assert!(OptionsToken::from_str("ndots:bad").is_err());
+        assert!(OptionsToken::from_str("timeout:bad").is_err());
+        assert!(OptionsToken::from_str("attempts:-5").is_err());
+    }
+
+    #[tokio::test]
+    async fn test_config_read_error() {
+        struct ErrAsyncRead;
+        impl AsyncRead for ErrAsyncRead {
+            fn poll_read(
+                self: Pin<&mut Self>,
+                _cx: &mut Context<'_>,
+                _buf: &mut ReadBuf<'_>,
+            ) -> Poll<std::io::Result<()>> {
+                Poll::Ready(Err(IOError::new(IOErrorKind::UnexpectedEof, "test error")))
+            }
+        }
+
+        let reader = ErrAsyncRead;
+        let res = config(reader).await.unwrap_err();
+        assert_eq!(ErrorKind::IO, res.kind());
+    }
+
+    #[tokio::test]
+    async fn test_config_no_content() {
+        let reader = Cursor::new(Vec::new());
+        let res = config(reader).await.unwrap();
+        assert_eq!(ResolvConf::default(), res);
+    }
+
+    #[tokio::test]
+    async fn test_config_all_comments() {
+        #[rustfmt::skip]
+        let reader = Cursor::new(concat!(
+            "# this is a comment\n",
+            "# another comment\n",
+        ));
+        let res = config(reader).await.unwrap();
+        assert_eq!(ResolvConf::default(), res);
+    }
+
+    #[tokio::test]
+    async fn test_config_all_unsupported() {
+        #[rustfmt::skip]
+        let reader = Cursor::new(concat!(
+            "scrambler 127.0.0.5\n",
+            "invalid directive\n",
+        ));
+        let res = config(reader).await.unwrap();
+        assert_eq!(ResolvConf::default(), res);
+    }
+
+    #[tokio::test]
+    async fn test_config_nameservers_search_invalid_options() {
+        #[rustfmt::skip]
+        let reader = Cursor::new(concat!(
+            "# this is a comment\n",
+            "nameserver 127.0.0.53\n",
+            "options casual-fridays:true\n",
+        ));
+
+        let expected = ResolvConf {
+            nameservers: vec!["127.0.0.53:53".parse().unwrap()],
+            options: Default::default(),
+        };
+
+        let res = config(reader).await.unwrap();
+        assert_eq!(expected, res);
+    }
+
+    #[tokio::test]
+    async fn test_config_nameservers_search_no_options() {
+        #[rustfmt::skip]
+        let reader = Cursor::new(concat!(
+            "# this is a comment\n",
+            "nameserver 127.0.0.53\n",
+        ));
+
+        let expected = ResolvConf {
+            nameservers: vec!["127.0.0.53:53".parse().unwrap()],
+            options: Default::default(),
+        };
+
+        let res = config(reader).await.unwrap();
+        assert_eq!(expected, res);
+    }
+
+    #[tokio::test]
+    async fn test_config_nameservers_search_options() {
+        #[rustfmt::skip]
+        let reader = Cursor::new(concat!(
+            "# this is a comment\n",
+            "nameserver 127.0.0.53\n",
+            "nameserver 127.0.0.54\n",
+            "nameserver 127.0.0.55\n",
+            "options ndots:3 attempts:5 timeout:10 rotate use-vc edns0\n",
+        ));
+
+        let expected = ResolvConf {
+            nameservers: vec![
+                "127.0.0.53:53".parse().unwrap(),
+                "127.0.0.54:53".parse().unwrap(),
+                "127.0.0.55:53".parse().unwrap(),
+            ],
+            options: ResolvConfOptions {
+                timeout: Duration::from_secs(10),
+                attempts: 5,
+                rotate: true,
+            },
+        };
+
+        let res = config(reader).await.unwrap();
+        assert_eq!(expected, res);
+    }
+}

--- a/mtop/src/check.rs
+++ b/mtop/src/check.rs
@@ -82,12 +82,7 @@ impl<'a> Checker<'a> {
 
             let dns_time = dns_start.elapsed();
             let conn_start = Instant::now();
-            let mut conn = match self
-                .client
-                .raw_open(&server)
-                .timeout(self.timeout, "client.raw_open")
-                .await
-            {
+            let mut conn = match self.client.raw_open(&server).timeout(self.timeout, "client.raw_open").await {
                 Ok(v) => v,
                 Err(e) => {
                     tracing::warn!(message = "failed to connect to host", host = host, addr = %server.address(), err = %e);
@@ -99,11 +94,7 @@ impl<'a> Checker<'a> {
 
             let conn_time = conn_start.elapsed();
             let set_start = Instant::now();
-            match conn
-                .set(&key, 0, 60, &val)
-                .timeout(self.timeout, "connection.set")
-                .await
-            {
+            match conn.set(&key, 0, 60, &val).timeout(self.timeout, "connection.set").await {
                 Ok(_) => {}
                 Err(e) => {
                     tracing::warn!(message = "failed to set key", host = host, addr = %server.address(), err = %e);

--- a/mtop/src/dns.rs
+++ b/mtop/src/dns.rs
@@ -1,0 +1,43 @@
+use mtop_client::dns::{DnsClient, ResolvConf};
+use mtop_client::MtopError;
+use std::fmt;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::path::Path;
+use tokio::fs::File;
+
+const DEFAULT_SERVER: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 53);
+
+/// Load configuration from the provided resolv.conf file and crated a new DnsClient
+/// based on it. If the resolv.conf file cannot be opened or is malformed, default
+/// configuration values will be used. See `man 5 resolv.conf` for more information.
+pub async fn new_client<P>(local: SocketAddr, resolv: P) -> DnsClient
+where
+    P: AsRef<Path> + fmt::Debug,
+{
+    let mut cfg = match load_config(&resolv).await {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            tracing::warn!(message = "unable to load resolv.conf", path = ?resolv, err = %e);
+            ResolvConf::default()
+        }
+    };
+
+    // Either the resolv.conf file doesn't list any nameservers or we had to
+    // use Default::default() which also doesn't include any. Use localhost in
+    // the hopes that it will work.
+    if cfg.nameservers.is_empty() {
+        cfg.nameservers.push(DEFAULT_SERVER);
+    }
+
+    DnsClient::new(local, cfg)
+}
+
+async fn load_config<P>(resolv: P) -> Result<ResolvConf, MtopError>
+where
+    P: AsRef<Path> + fmt::Debug,
+{
+    let handle = File::open(&resolv)
+        .await
+        .map_err(|e| MtopError::configuration_cause(format!("unable to open {:?}", resolv), e))?;
+    mtop_client::dns::config(handle).await
+}

--- a/mtop/src/lib.rs
+++ b/mtop/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod bench;
 pub mod check;
+pub mod dns;
 pub mod profile;
 pub mod queue;
 pub mod tracing;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,2 @@
 max_width = 120
+chain_width = 80


### PR DESCRIPTION
Allow some DNS settings to be read from a system's /etc/resolv.conf
file. Noteably, only the `nameserver` and a few `option`s are supported
for now. This change also switches resolution of A and AAAA names to
our DNS client instead of using the system resolver via `lookup_host`.


Part of #107