### PR TITLE
dns: initial opt record support

### DIFF
--- a/mtop-client/src/dns/mod.rs
+++ b/mtop-client/src/dns/mod.rs
@@ -10,7 +10,7 @@ pub use crate::dns::core::{RecordClass, RecordType};
 pub use crate::dns::message::{Flags, Message, MessageId, Operation, Question, Record, ResponseCode};
 pub use crate::dns::name::Name;
 pub use crate::dns::rdata::{
-    RecordData, RecordDataA, RecordDataAAAA, RecordDataCNAME, RecordDataNS, RecordDataSOA, RecordDataSRV,
-    RecordDataTXT, RecordDataUnknown,
+    RecordData, RecordDataA, RecordDataAAAA, RecordDataCNAME, RecordDataNS, RecordDataOpt, RecordDataSOA,
+    RecordDataSRV, RecordDataTXT, RecordDataUnknown,
 };
 pub use crate::dns::resolv::{config, ResolvConf, ResolvConfOptions};

--- a/mtop-client/src/dns/resolv.rs
+++ b/mtop-client/src/dns/resolv.rs
@@ -164,14 +164,11 @@ impl OptionsToken {
     const MAX_ATTEMPTS: u8 = 5;
 
     fn parse(line: &str, val: &str, max: u8) -> Result<u8, MtopError> {
-        let n = val
+        let n: u8 = val
             .parse()
             .map_err(|e| MtopError::configuration_cause(format!("unable to parse {} value '{}'", line, val), e))?;
-        if n > max {
-            Ok(max)
-        } else {
-            Ok(n)
-        }
+
+        Ok(n.min(max))
     }
 }
 

--- a/mtop/src/bin/mc.rs
+++ b/mtop/src/bin/mc.rs
@@ -8,7 +8,6 @@ use mtop_client::{
 };
 use std::fs::File;
 use std::io::Write;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::time::Duration;
@@ -18,7 +17,6 @@ use tokio::runtime::Handle;
 use tracing::{Instrument, Level};
 use webpki::types::{InvalidDnsNameError, ServerName};
 
-const DEFAULT_DNS_LOCAL: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0);
 const DEFAULT_LOG_LEVEL: Level = Level::INFO;
 const DEFAULT_HOST: &str = "localhost:11211";
 const DEFAULT_TIMEOUT_SECS: u64 = 30;
@@ -32,10 +30,6 @@ struct McConfig {
     /// (case-insensitive).
     #[arg(long, default_value_t = DEFAULT_LOG_LEVEL)]
     log_level: Level,
-
-    /// Local address for DNS requests for service discovery in the form 'address:port'
-    #[arg(long, default_value_t = DEFAULT_DNS_LOCAL)]
-    dns_local: SocketAddr,
 
     /// Path to resolv.conf file for loading DNS configuration information. If this file
     /// can't be loaded, default values for DNS configuration are used instead.
@@ -299,7 +293,7 @@ async fn main() -> ExitCode {
         mtop::tracing::console_subscriber(opts.log_level).expect("failed to setup console logging");
     tracing::subscriber::set_global_default(console_subscriber).expect("failed to initialize console logging");
 
-    let dns_client = mtop::dns::new_client(opts.dns_local, &opts.resolv_conf).await;
+    let dns_client = mtop::dns::new_client(&opts.resolv_conf).await;
     let resolver = DiscoveryDefault::new(dns_client);
     let timeout = Duration::from_secs(opts.timeout_secs);
     let servers = match resolver

--- a/mtop/src/dns.rs
+++ b/mtop/src/dns.rs
@@ -7,10 +7,10 @@ use tokio::fs::File;
 
 const DEFAULT_SERVER: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 53);
 
-/// Load configuration from the provided resolv.conf file and crated a new DnsClient
+/// Load configuration from the provided resolv.conf file and create a new DnsClient
 /// based on it. If the resolv.conf file cannot be opened or is malformed, default
 /// configuration values will be used. See `man 5 resolv.conf` for more information.
-pub async fn new_client<P>(local: SocketAddr, resolv: P) -> DnsClient
+pub async fn new_client<P>(resolv: P) -> DnsClient
 where
     P: AsRef<Path> + fmt::Debug,
 {
@@ -29,7 +29,7 @@ where
         cfg.nameservers.push(DEFAULT_SERVER);
     }
 
-    DnsClient::new(local, cfg)
+    DnsClient::new(cfg)
 }
 
 async fn load_config<P>(resolv: P) -> Result<ResolvConf, MtopError>


### PR DESCRIPTION
This change introduces the ability to parse OPT records but does not yet add them to requests or uses them when they are part of a response. A future PR will start making use of OPT records.

This change also does some unrelated cleanup, removing `--dns-local` flags from each of the binaries in favor of picking this value automatically. Additionally, the `--timeout-secs` option is removed from the `dns` binary since it has been unused since resolv.conf support was added.

Part of #107