### PR TITLE
Introduce pooling for DNS client and split net/pooling logic

### DIFF
--- a/mtop-client/src/dns/mod.rs
+++ b/mtop-client/src/dns/mod.rs
@@ -5,7 +5,7 @@ mod name;
 mod rdata;
 mod resolv;
 
-pub use crate::dns::client::DnsClient;
+pub use crate::dns::client::{DnsClient, DnsClientConfig};
 pub use crate::dns::core::{RecordClass, RecordType};
 pub use crate::dns::message::{Flags, Message, MessageId, Operation, Question, Record, ResponseCode};
 pub use crate::dns::name::Name;

--- a/mtop-client/src/dns/resolv.rs
+++ b/mtop-client/src/dns/resolv.rs
@@ -20,22 +20,11 @@ pub struct ResolvConf {
 /// Options to change the behavior of a DNS client based on a resolv.conf file.
 ///
 /// Note that only a subset of options are supported.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct ResolvConfOptions {
-    pub timeout: Duration,
-    pub attempts: u8,
-    pub rotate: bool,
-}
-
-impl Default for ResolvConfOptions {
-    fn default() -> Self {
-        // Defaults picked based on `man 5 resolv.conf`
-        Self {
-            timeout: Duration::from_secs(5),
-            attempts: 2,
-            rotate: false,
-        }
-    }
+    pub timeout: Option<Duration>,
+    pub attempts: Option<u8>,
+    pub rotate: Option<bool>,
 }
 
 /// Read settings for a DNS client from a resolv.conf configuration file.
@@ -71,13 +60,13 @@ where
                 for opt in parse_options(parts) {
                     match opt {
                         OptionsToken::Timeout(t) => {
-                            conf.options.timeout = Duration::from_secs(u64::from(t));
+                            conf.options.timeout = Some(Duration::from_secs(u64::from(t)));
                         }
                         OptionsToken::Attempts(n) => {
-                            conf.options.attempts = n;
+                            conf.options.attempts = Some(n);
                         }
                         OptionsToken::Rotate => {
-                            conf.options.rotate = true;
+                            conf.options.rotate = Some(true);
                         }
                     }
                 }
@@ -330,9 +319,9 @@ mod test {
                 "127.0.0.55:53".parse().unwrap(),
             ],
             options: ResolvConfOptions {
-                timeout: Duration::from_secs(10),
-                attempts: 5,
-                rotate: true,
+                timeout: Some(Duration::from_secs(10)),
+                attempts: Some(5),
+                rotate: Some(true),
             },
         };
 

--- a/mtop-client/src/lib.rs
+++ b/mtop-client/src/lib.rs
@@ -2,14 +2,18 @@ mod client;
 mod core;
 mod discovery;
 pub mod dns;
+mod net;
 mod pool;
 mod timeout;
 
-pub use crate::client::{MemcachedClient, SelectorRendezvous, ServersResponse, ValuesResponse};
+pub use crate::client::{
+    MemcachedClient, MemcachedPool, MemcachedPoolConfig, SelectorRendezvous, ServersResponse, ValuesResponse,
+};
 pub use crate::core::{
     ErrorKind, Key, Memcached, Meta, MtopError, ProtocolError, ProtocolErrorKind, Slab, SlabItem, SlabItems, Slabs,
     Stats, Value,
 };
 pub use crate::discovery::{DiscoveryDefault, Server, ServerID};
-pub use crate::pool::{MemcachedPool, PoolConfig, PooledMemcached, TLSConfig};
+pub use crate::net::TlsConfig;
+pub use crate::pool::PooledClient;
 pub use crate::timeout::{Timed, Timeout};

--- a/mtop-client/src/net.rs
+++ b/mtop-client/src/net.rs
@@ -1,0 +1,143 @@
+use crate::core::MtopError;
+use std::fmt::{self, Debug};
+use std::fs::File;
+use std::io::{self, BufReader};
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::io::{ReadHalf, WriteHalf};
+use tokio::net::{TcpStream, ToSocketAddrs};
+use tokio::runtime::Handle;
+use tokio_rustls::client::TlsStream;
+use tokio_rustls::rustls::{ClientConfig, RootCertStore};
+use tokio_rustls::TlsConnector;
+use webpki::types::{CertificateDer, PrivateKeyDer, ServerName};
+
+/// Configuration for establishing a TLS connection to server with optional mTLS.
+#[derive(Debug, Clone, Default)]
+pub struct TlsConfig {
+    /// Enable TLS connections to the server.
+    pub enabled: bool,
+
+    /// Path to a custom certificate authority. If not supplied, default root certificates
+    /// from the `webpki_roots` crate are used.
+    pub ca_path: Option<PathBuf>,
+
+    /// Path to a PEM format client certificate for mTLS. If not supplied, no client authentication
+    /// is used when connecting to the server.
+    pub cert_path: Option<PathBuf>,
+
+    /// Path to a PEM format client key for mTLS. If not supplied, no client authentication is used
+    /// when connecting to the server.
+    pub key_path: Option<PathBuf>,
+
+    /// Name of the server for validating its certificate. If not supplied, the hostname
+    /// of the server is used instead.
+    pub server_name: Option<ServerName<'static>>,
+}
+
+pub(crate) async fn tls_client_config(handle: Handle, config: TlsConfig) -> Result<ClientConfig, MtopError> {
+    handle.spawn_blocking(move || client_config(config)).await.unwrap()
+}
+
+fn client_config(tls: TlsConfig) -> Result<ClientConfig, MtopError> {
+    let client_cert = if let Some(p) = &tls.cert_path {
+        Some(load_cert(p)?)
+    } else {
+        None
+    };
+
+    let client_key = if let Some(p) = &tls.key_path {
+        Some(load_key(p)?)
+    } else {
+        None
+    };
+
+    let root = if let Some(p) = &tls.ca_path {
+        custom_root_store(load_cert(p)?)?
+    } else {
+        default_root_store()
+    };
+
+    let builder = ClientConfig::builder().with_root_certificates(root);
+    let config = match (client_cert, client_key, tls.cert_path, tls.key_path) {
+        (Some(cert), Some(key), Some(cert_path), Some(key_path)) => {
+            tracing::debug!(message = "using key and cert for client authentication", key = ?key_path, cert = ?cert_path);
+            builder
+                .with_client_auth_cert(cert, key)
+                .map_err(|e| MtopError::configuration_cause("unable to use client cert or key", e))?
+        }
+        _ => {
+            tracing::debug!(message = "not using any client authentication");
+            builder.with_no_client_auth()
+        }
+    };
+
+    Ok(config)
+}
+
+fn load_cert(path: &PathBuf) -> Result<Vec<CertificateDer<'static>>, MtopError> {
+    File::open(path)
+        .map(BufReader::new)
+        .map(|mut r| rustls_pemfile::certs(&mut r).collect::<Vec<_>>())
+        .and_then(|v| v.into_iter().collect::<Result<Vec<CertificateDer<'static>>, io::Error>>())
+        .map_err(|e| MtopError::configuration_cause(format!("unable to load or parse cert {:?}", path), e))
+}
+
+fn load_key(path: &PathBuf) -> Result<PrivateKeyDer<'static>, MtopError> {
+    File::open(path)
+        .map(BufReader::new)
+        .and_then(|mut r| rustls_pemfile::private_key(&mut r))
+        .map_err(|e| MtopError::configuration_cause(format!("unable to load key {:?}", path), e))?
+        .ok_or_else(|| MtopError::configuration(format!("no keys available in {:?}", path)))
+}
+
+fn custom_root_store(ca: Vec<CertificateDer<'static>>) -> Result<RootCertStore, MtopError> {
+    let mut store = RootCertStore::empty();
+    for cert in ca {
+        store
+            .add(cert)
+            .map_err(|e| MtopError::configuration_cause("unable to parse CA cert", e))?;
+    }
+
+    Ok(store)
+}
+
+fn default_root_store() -> RootCertStore {
+    let mut store = RootCertStore::empty();
+    store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().map(|c| c.to_owned()));
+    store
+}
+
+pub(crate) async fn tcp_connect<A>(host: A) -> Result<(ReadHalf<TcpStream>, WriteHalf<TcpStream>), MtopError>
+where
+    A: ToSocketAddrs + fmt::Display,
+{
+    let tcp_stream = tcp_stream(host).await?;
+    Ok(tokio::io::split(tcp_stream))
+}
+
+pub(crate) async fn tcp_tls_connect<A>(
+    host: A,
+    server: ServerName<'static>,
+    config: Arc<ClientConfig>,
+) -> Result<(ReadHalf<TlsStream<TcpStream>>, WriteHalf<TlsStream<TcpStream>>), MtopError>
+where
+    A: ToSocketAddrs + fmt::Display,
+{
+    let tcp_stream = tcp_stream(host).await?;
+    let connector = TlsConnector::from(config);
+    let tls_stream = connector.connect(server, tcp_stream).await?;
+    Ok(tokio::io::split(tls_stream))
+}
+
+async fn tcp_stream<A>(host: A) -> Result<TcpStream, MtopError>
+where
+    A: ToSocketAddrs + fmt::Display,
+{
+    TcpStream::connect(&host)
+        .await
+        // The client buffers and flushes writes so we don't need delay here to
+        // avoid lots of tiny packets.
+        .and_then(|s| s.set_nodelay(true).map(|_| s))
+        .map_err(|e| MtopError::from((host.to_string(), e)))
+}

--- a/mtop-client/src/pool.rs
+++ b/mtop-client/src/pool.rs
@@ -1,368 +1,200 @@
-use crate::core::{Memcached, MtopError};
-use crate::discovery::Server;
+use crate::core::MtopError;
 use std::collections::HashMap;
-use std::fmt::{self, Debug};
-use std::fs::File;
-use std::future::Future;
-use std::io::{self, BufReader};
+use std::fmt;
+use std::hash::Hash;
 use std::ops::{Deref, DerefMut};
-use std::path::PathBuf;
-use std::sync::Arc;
-use tokio::net::TcpStream;
-use tokio::runtime::Handle;
 use tokio::sync::Mutex;
-use tokio_rustls::rustls::{ClientConfig, RootCertStore};
-use tokio_rustls::TlsConnector;
-use webpki::types::{CertificateDer, PrivateKeyDer, ServerName};
 
-#[derive(Debug)]
-pub struct PooledMemcached {
-    inner: Memcached,
-    host: Server,
+pub(crate) trait ClientFactory<K, V> {
+    async fn make(&self, key: &K) -> Result<V, MtopError>;
 }
 
-impl Deref for PooledMemcached {
-    type Target = Memcached;
+#[derive(Debug, Clone)]
+pub(crate) struct ClientPoolConfig {
+    pub name: String,
+    pub max_idle: u64,
+}
+
+#[derive(Debug)]
+pub(crate) struct ClientPool<K, V, F>
+where
+    K: Eq + Hash + Clone + fmt::Display,
+    F: ClientFactory<K, V>,
+{
+    clients: Mutex<HashMap<K, Vec<PooledClient<K, V>>>>,
+    config: ClientPoolConfig,
+    factory: F,
+}
+
+impl<K, V, F> ClientPool<K, V, F>
+where
+    K: Eq + Hash + Clone + fmt::Display,
+    F: ClientFactory<K, V>,
+{
+    pub(crate) fn new(config: ClientPoolConfig, factory: F) -> Self {
+        Self {
+            clients: Mutex::new(HashMap::new()),
+            config,
+            factory,
+        }
+    }
+
+    pub(crate) async fn get(&self, key: &K) -> Result<PooledClient<K, V>, MtopError> {
+        // Lock the clients HashMap and try to get an existing client in a limited scope
+        // so that we don't hold the lock while trying to connect if there are no exising
+        // clients.
+        let client = {
+            let mut clients = self.clients.lock().await;
+            clients.get_mut(key).and_then(|v| v.pop())
+        };
+
+        match client {
+            Some(c) => {
+                tracing::trace!(message = "using existing client", pool = self.config.name, server = %key);
+                Ok(c)
+            }
+            None => {
+                tracing::trace!(message = "creating new client", pool = self.config.name, server = %key);
+                let inner = self.factory.make(key).await?;
+                Ok(PooledClient {
+                    key: key.clone(),
+                    inner,
+                })
+            }
+        }
+    }
+
+    pub(crate) async fn put(&self, client: PooledClient<K, V>) {
+        let mut clients = self.clients.lock().await;
+        let entries = clients.entry(client.key.clone()).or_default();
+        if (entries.len() as u64) < self.config.max_idle {
+            entries.push(client);
+        }
+    }
+}
+
+/// Wrapper for a client that belongs to a pool and must be returned
+/// to the pool when complete.
+#[derive(Debug)]
+pub struct PooledClient<K, V> {
+    key: K,
+    inner: V,
+}
+
+impl<K, V> Deref for PooledClient<K, V> {
+    type Target = V;
 
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
 
-impl DerefMut for PooledMemcached {
+impl<K, V> DerefMut for PooledClient<K, V> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
 
-#[derive(Debug)]
-pub struct PoolConfig {
-    pub max_idle_per_host: u64,
-    pub check_on_get: bool,
-    pub check_on_put: bool,
-    pub tls: TLSConfig,
-}
-
-impl Default for PoolConfig {
-    fn default() -> Self {
-        Self {
-            max_idle_per_host: 4,
-            check_on_get: false,
-            check_on_put: false,
-            tls: TLSConfig::default(),
-        }
-    }
-}
-
-#[derive(Debug, Default)]
-pub struct TLSConfig {
-    pub enabled: bool,
-    pub ca_path: Option<PathBuf>,
-    pub cert_path: Option<PathBuf>,
-    pub key_path: Option<PathBuf>,
-    pub server_name: Option<ServerName<'static>>,
-}
-
-#[derive(Debug)]
-pub struct MemcachedPool {
-    connections: Mutex<HashMap<Server, Vec<Memcached>>>,
-    client_config: Option<Arc<ClientConfig>>,
-    config: PoolConfig,
-}
-
-impl MemcachedPool {
-    pub async fn new(handle: Handle, config: PoolConfig) -> Result<Self, MtopError> {
-        let client_config = if config.tls.enabled {
-            Some(Arc::new(Self::client_config(handle, &config.tls).await?))
-        } else {
-            None
-        };
-
-        Ok(MemcachedPool {
-            connections: Mutex::new(HashMap::new()),
-            client_config,
-            config,
-        })
-    }
-
-    async fn client_config(handle: Handle, tls: &TLSConfig) -> Result<ClientConfig, MtopError> {
-        let ca = if let Some(p) = &tls.ca_path {
-            let certs = Self::load_cert(&handle, p).await?;
-            tracing::debug!(message = "loaded CA certs", num_certs = certs.len(), path = ?p);
-            Some(certs)
-        } else {
-            None
-        };
-
-        let client_cert = if let Some(p) = &tls.cert_path {
-            let certs = Self::load_cert(&handle, p).await?;
-            tracing::debug!(message = "loaded client certs", num_certs = certs.len(), path = ?p);
-            Some(certs)
-        } else {
-            None
-        };
-
-        let client_key = if let Some(p) = &tls.key_path {
-            let keys = Self::load_key(&handle, p).await?;
-            tracing::debug!(message = "loaded client key", path = ?p);
-            Some(keys)
-        } else {
-            None
-        };
-
-        let trust_store = Self::trust_store(ca)?;
-        let builder = ClientConfig::builder().with_root_certificates(trust_store);
-
-        let config = match (client_cert, client_key) {
-            (Some(cert), Some(key)) => {
-                tracing::debug!(message = "using key and cert for client authentication");
-                builder
-                    .with_client_auth_cert(cert, key)
-                    .map_err(|e| MtopError::configuration_cause("unable to use client cert or key", e))?
-            }
-            _ => {
-                tracing::debug!(message = "not using any client authentication");
-                builder.with_no_client_auth()
-            }
-        };
-
-        Ok(config)
-    }
-
-    async fn load_cert(handle: &Handle, path: &PathBuf) -> Result<Vec<CertificateDer<'static>>, MtopError> {
-        let mut reader = File::open(path)
-            .map(BufReader::new)
-            .map_err(|e| MtopError::configuration_cause(format!("unable to load cert {:?}", path), e))?;
-
-        // Read all certs from the file in a separate thread and then convert the awkward
-        // Vec<Result<Cert>> type to a Result<Vec<Cert>> since we expect all certs to be valid
-        handle
-            .spawn_blocking(move || rustls_pemfile::certs(&mut reader).collect::<Vec<_>>())
-            .await
-            .unwrap()
-            .into_iter()
-            .collect::<Result<Vec<CertificateDer<'static>>, io::Error>>()
-            .map_err(|e| MtopError::configuration_cause(format!("unable to parse cert {:?}", path), e))
-    }
-
-    async fn load_key(handle: &Handle, path: &PathBuf) -> Result<PrivateKeyDer<'static>, MtopError> {
-        let mut reader = File::open(path)
-            .map(BufReader::new)
-            .map_err(|e| MtopError::configuration_cause(format!("unable to load key {:?}", path), e))?;
-
-        // Read a single key in a separate thread returning an error if there is no key.
-        handle
-            .spawn_blocking(move || rustls_pemfile::private_key(&mut reader))
-            .await
-            .unwrap()
-            .map_err(|e| MtopError::configuration_cause(format!("unable to parse key {:?}", path), e))?
-            .ok_or_else(|| MtopError::configuration(format!("no keys available in {:?}", path)))
-    }
-
-    fn trust_store(ca: Option<Vec<CertificateDer<'static>>>) -> Result<RootCertStore, MtopError> {
-        let mut root_cert_store = RootCertStore::empty();
-
-        if let Some(ca_certs) = ca {
-            tracing::debug!(message = "adding custom CA certs for roots", num_certs = ca_certs.len());
-            for cert in ca_certs {
-                root_cert_store
-                    .add(cert)
-                    .map_err(|e| MtopError::runtime_cause("unable to parse CA cert", e))?;
-            }
-        } else {
-            tracing::debug!(message = "using default CA certs for roots");
-            root_cert_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().map(|c| c.to_owned()));
-        }
-
-        Ok(root_cert_store)
-    }
-
-    async fn connect(&self, server: &Server) -> Result<Memcached, MtopError> {
-        if let Some(cfg) = &self.client_config {
-            let name = self.config.tls.server_name.clone().unwrap_or_else(|| server.server_name());
-            tracing::debug!(message = "using server name for TLS validation", server_name = ?name);
-            tls_connect(server.address(), name, cfg.clone()).await
-        } else {
-            plain_connect(server.address()).await
-        }
-    }
-
-    /// Get an existing connection to the given server from the pool or establish a new one
-    /// based on the configuration set when this pool was created (plaintext or TLS with
-    /// optional client certificate).
-    pub async fn get(&self, server: &Server) -> Result<PooledMemcached, MtopError> {
-        self.get_with_connect(server, self.connect(server)).await
-    }
-
-    /// Get an existing connection to the given server from the pool or establish a new one
-    /// using the provided `Future` which is expected to create a `Memcached` instance. Note
-    /// that this method relies on the fact that futures do nothing unless polled to avoid
-    /// making a connection when not required.
-    async fn get_with_connect<F>(&self, server: &Server, connect: F) -> Result<PooledMemcached, MtopError>
-    where
-        F: Future<Output = Result<Memcached, MtopError>>,
-    {
-        let mut map = self.connections.lock().await;
-        let mut inner = match map.get_mut(server).and_then(|v| v.pop()) {
-            Some(c) => c,
-            None => connect.await?,
-        };
-
-        if self.config.check_on_get {
-            inner.ping().await?;
-        }
-
-        Ok(PooledMemcached {
-            inner,
-            host: server.clone(),
-        })
-    }
-
-    /// Return a connection to the pool if there are currently fewer than `max_idle_per_host`
-    /// connections to the host this client is for. If there are more connections, the returned
-    /// client is closed immediately.
-    pub async fn put(&self, mut conn: PooledMemcached) {
-        if !self.config.check_on_put || conn.ping().await.is_ok() {
-            let mut map = self.connections.lock().await;
-            let conns = map.entry(conn.host).or_default();
-
-            if (conns.len() as u64) < self.config.max_idle_per_host {
-                conns.push(conn.inner);
-            }
-        }
-    }
-}
-
-async fn plain_connect<A>(host: A) -> Result<Memcached, MtopError>
-where
-    A: tokio::net::ToSocketAddrs + fmt::Display,
-{
-    let tcp_stream = tcp_stream(host).await?;
-    let (read, write) = tcp_stream.into_split();
-    Ok(Memcached::new(read, write))
-}
-
-async fn tls_connect<A>(host: A, server: ServerName<'static>, config: Arc<ClientConfig>) -> Result<Memcached, MtopError>
-where
-    A: tokio::net::ToSocketAddrs + fmt::Display,
-{
-    let tcp_stream = tcp_stream(host).await?;
-    let connector = TlsConnector::from(config);
-    let tls_stream = connector.connect(server, tcp_stream).await?;
-    let (read, write) = tokio::io::split(tls_stream);
-    Ok(Memcached::new(read, write))
-}
-
-async fn tcp_stream<A>(host: A) -> Result<TcpStream, MtopError>
-where
-    A: tokio::net::ToSocketAddrs + fmt::Display,
-{
-    TcpStream::connect(&host)
-        .await
-        // The client buffers and flushes writes so we don't need delay here to
-        // avoid lots of tiny packets.
-        .and_then(|s| s.set_nodelay(true).map(|_| s))
-        .map_err(|e| MtopError::from((host.to_string(), e)))
-}
-
 #[cfg(test)]
 mod test {
-    use super::{MemcachedPool, PoolConfig, PooledMemcached};
-    use crate::core::{ErrorKind, Memcached, MtopError};
-    use crate::discovery::{Server, ServerID};
-    use std::io::{self, Cursor};
-    use std::net::SocketAddr;
-    use tokio::runtime::Handle;
-    use webpki::types::ServerName;
+    use super::{ClientFactory, ClientPool, ClientPoolConfig};
+    use crate::core::MtopError;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::Arc;
 
-    /// Create a new `Memcached` instance to read the provided server response.
-    macro_rules! client {
-        ($($line:expr),+ $(,)?) => ({
-            let writes = Vec::new();
-            let mut reads = Vec::new();
-            $(reads.extend_from_slice($line.as_bytes());)+
-            Memcached::new(Cursor::new(reads), writes)
-        })
+    struct CountingClient {
+        dropped: Arc<AtomicU64>,
     }
 
-    #[tokio::test]
-    async fn test_get_new_connection() {
-        let cfg = PoolConfig::default();
-        let pool = MemcachedPool::new(Handle::current(), cfg).await.unwrap();
-        let id = ServerID::from("127.0.0.1:11211".parse::<SocketAddr>().unwrap());
-        let server = Server::new(id, ServerName::try_from("localhost").unwrap().to_owned());
+    impl Drop for CountingClient {
+        fn drop(&mut self) {
+            self.dropped.fetch_add(1, Ordering::Release);
+        }
+    }
 
-        let connect = async {
-            Ok(client!(
-                "VERSION 1.6.20\r\n",
-                "VERSION 1.6.20\r\n",
-                "VERSION 1.6.20\r\n"
-            ))
+    struct CountingClientFactory {
+        created: Arc<AtomicU64>,
+        dropped: Arc<AtomicU64>,
+    }
+
+    impl ClientFactory<String, CountingClient> for CountingClientFactory {
+        async fn make(&self, _key: &String) -> Result<CountingClient, MtopError> {
+            self.created.fetch_add(1, Ordering::Release);
+
+            Ok(CountingClient {
+                dropped: self.dropped.clone(),
+            })
+        }
+    }
+
+    fn new_pool(
+        created: Arc<AtomicU64>,
+        dropped: Arc<AtomicU64>,
+    ) -> ClientPool<String, CountingClient, CountingClientFactory> {
+        let factory = CountingClientFactory {
+            created: created.clone(),
+            dropped: dropped.clone(),
+        };
+        let pool_cfg = ClientPoolConfig {
+            name: "test".to_owned(),
+            max_idle: 1,
         };
 
-        let client = pool.get_with_connect(&server, connect).await;
-        assert!(client.is_ok());
+        ClientPool::new(pool_cfg, factory)
     }
 
     #[tokio::test]
-    async fn test_get_existing_connection() {
-        let cfg = PoolConfig::default();
-        let pool = MemcachedPool::new(Handle::current(), cfg).await.unwrap();
+    async fn test_client_pool_get_empty_pool() {
+        let created = Arc::new(AtomicU64::new(0));
+        let dropped = Arc::new(AtomicU64::new(0));
+        let pool = new_pool(created.clone(), dropped.clone());
 
-        let id = ServerID::from("127.0.0.1:11211".parse::<SocketAddr>().unwrap());
-        let server = Server::new(id, ServerName::try_from("localhost").unwrap().to_owned());
+        let _client = pool.get(&"whatever".to_owned()).await.unwrap();
 
-        pool.put(PooledMemcached {
-            host: server.clone(),
-            inner: client!("VERSION 1.6.20\r\n", "VERSION 1.6.20\r\n", "VERSION 1.6.20\r\n"),
-        })
-        .await;
-
-        let connect = async { panic!("should not be called!") };
-        let res = pool.get_with_connect(&server, connect).await;
-        assert!(res.is_ok());
+        assert_eq!(1, created.load(Ordering::Acquire));
+        assert_eq!(0, dropped.load(Ordering::Acquire));
     }
 
     #[tokio::test]
-    async fn test_get_dead_connection() {
-        let cfg = PoolConfig {
-            max_idle_per_host: 4,
-            check_on_get: true,
-            check_on_put: true,
-            ..Default::default()
-        };
+    async fn test_client_pool_get_existing_client() {
+        let created = Arc::new(AtomicU64::new(0));
+        let dropped = Arc::new(AtomicU64::new(0));
+        let pool = new_pool(created.clone(), dropped.clone());
 
-        let pool = MemcachedPool::new(Handle::current(), cfg).await.unwrap();
-        let id = ServerID::from("127.0.0.1:11211".parse::<SocketAddr>().unwrap());
-        let server = Server::new(id, ServerName::try_from("localhost").unwrap().to_owned());
+        let client1 = pool.get(&"whatever".to_owned()).await.unwrap();
+        pool.put(client1).await;
+        let _client2 = pool.get(&"whatever".to_owned()).await.unwrap();
 
-        pool.put(PooledMemcached {
-            host: server.clone(),
-            inner: client!("VERSION 1.6.20\r\n", "ERROR Too many open connections\r\n"),
-        })
-        .await;
-
-        let connect = async { panic!("should not be called!") };
-        let res = pool.get_with_connect(&server, connect).await;
-
-        assert!(res.is_err());
-        let err = res.unwrap_err();
-        assert_eq!(ErrorKind::Protocol, err.kind());
+        assert_eq!(1, created.load(Ordering::Acquire));
+        assert_eq!(0, dropped.load(Ordering::Acquire));
     }
 
     #[tokio::test]
-    async fn test_get_error() {
-        let cfg = PoolConfig::default();
-        let pool = MemcachedPool::new(Handle::current(), cfg).await.unwrap();
+    async fn test_client_pool_put_at_max_idle() {
+        let created = Arc::new(AtomicU64::new(0));
+        let dropped = Arc::new(AtomicU64::new(0));
+        let pool = new_pool(created.clone(), dropped.clone());
 
-        let id = ServerID::from("127.0.0.1:11211".parse::<SocketAddr>().unwrap());
-        let server = Server::new(id, ServerName::try_from("localhost").unwrap().to_owned());
+        let client1 = pool.get(&"whatever".to_owned()).await.unwrap();
+        let client2 = pool.get(&"whatever".to_owned()).await.unwrap();
+        pool.put(client1).await;
+        pool.put(client2).await;
 
-        let connect = async { Err(MtopError::from(io::Error::new(io::ErrorKind::TimedOut, "timeout"))) };
-        let res = pool.get_with_connect(&server, connect).await;
+        assert_eq!(2, created.load(Ordering::Acquire));
+        assert_eq!(1, dropped.load(Ordering::Acquire));
+    }
 
-        assert!(res.is_err());
-        let err = res.unwrap_err();
-        assert_eq!(ErrorKind::IO, err.kind());
+    #[tokio::test]
+    async fn test_client_pool_put_zero_max_idle() {
+        let created = Arc::new(AtomicU64::new(0));
+        let dropped = Arc::new(AtomicU64::new(0));
+        let mut pool = new_pool(created.clone(), dropped.clone());
+        pool.config.max_idle = 0;
+
+        let client = pool.get(&"whatever".to_owned()).await.unwrap();
+        pool.put(client).await;
+
+        assert_eq!(1, created.load(Ordering::Acquire));
+        assert_eq!(1, dropped.load(Ordering::Acquire));
     }
 }


### PR DESCRIPTION
Introduce a generic pooling type for use in both the DnsClient and MemcachedClient. This required splitting the pooling logic from the networking and TLS code.