### PR TITLE
Various improvements to bench, check, ping commands

### DIFF
--- a/mtop/src/bin/mtop.rs
+++ b/mtop/src/bin/mtop.rs
@@ -119,7 +119,7 @@ async fn main() -> ExitCode {
 
     let timeout = Duration::from_secs(opts.timeout_secs);
     let measurements = Arc::new(StatsQueue::new(NUM_MEASUREMENTS));
-    let dns_client = mtop::dns::new_client(&opts.resolv_conf).await;
+    let dns_client = mtop::dns::new_client(&opts.resolv_conf, None, None).await;
     let resolver = DiscoveryDefault::new(dns_client);
 
     let servers = match expand_hosts(&opts.hosts, &resolver, timeout).await {

--- a/mtop/src/lib.rs
+++ b/mtop/src/lib.rs
@@ -3,7 +3,9 @@
 pub mod bench;
 pub mod check;
 pub mod dns;
+pub mod ping;
 pub mod profile;
 pub mod queue;
+pub mod sig;
 pub mod tracing;
 pub mod ui;

--- a/mtop/src/ping.rs
+++ b/mtop/src/ping.rs
@@ -1,0 +1,106 @@
+use crate::check::{Timing, TimingBuilder};
+use mtop_client::dns::{DnsClient, Name, RecordClass, RecordType, ResponseCode};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::time;
+use tracing::{Instrument, Level};
+
+/// Repeatedly make DNS requests to resolve a domain name.
+#[derive(Debug)]
+pub struct DnsPinger {
+    client: DnsClient,
+    interval: Duration,
+    stop: Arc<AtomicBool>,
+}
+
+impl DnsPinger {
+    /// Create a new `DnsPinger` that uses the provided client to repeatedly resolve a domain
+    /// name. `interval` is the amount of time to wait between each DNS query.
+    pub fn new(client: DnsClient, interval: Duration, stop: Arc<AtomicBool>) -> Self {
+        Self { client, interval, stop }
+    }
+
+    /// Perform DNS queries for a particular domain name up to `count` times or until stopped
+    /// via the `stop` flag if `count` is `0` (indicating "infinite" queries).
+    pub async fn run(&self, name: Name, rtype: RecordType, rclass: RecordClass, count: u64) -> Bundle {
+        let mut timing_builder = TimingBuilder::default();
+        let mut total = 0;
+        let mut protocol_errors = 0;
+        let mut fatal_errors = 0;
+
+        let mut interval = time::interval(self.interval);
+
+        while !self.stop.load(Ordering::Acquire) && (count == 0 || total < count) {
+            let _ = interval.tick().await;
+            // Create our own Instant to measure the time taken to perform the query since
+            // the one emitted by the interval isn't _immediately_ when the future resolves
+            // and so skews the measurement of queries.
+            let start = Instant::now();
+
+            match self
+                .client
+                .resolve(name.clone(), rtype, rclass)
+                .instrument(tracing::span!(Level::INFO, "client.resolve"))
+                .await
+            {
+                Ok(r) => {
+                    let min_ttl = r.answers().iter().map(|a| a.ttl()).min().unwrap_or(0);
+                    let elapsed = start.elapsed();
+                    timing_builder.add(elapsed);
+
+                    // Warn if the name couldn't be resolved correctly. This is different from
+                    // an error like a timeout since we did actually get a response for the query
+                    if r.flags().get_response_code() != ResponseCode::NoError {
+                        tracing::warn!(
+                            id = %r.id(),
+                            name = %name,
+                            response_code = ?r.flags().get_response_code(),
+                            num_questions = r.questions().len(),
+                            num_answers = r.answers().len(),
+                            num_authority = r.authority().len(),
+                            num_extra = r.extra().len(),
+                            min_ttl = min_ttl,
+                            elapsed = ?elapsed,
+                        );
+                        protocol_errors += 1;
+                    } else {
+                        tracing::info!(
+                            id = %r.id(),
+                            name = %name,
+                            response_code = ?r.flags().get_response_code(),
+                            num_questions = r.questions().len(),
+                            num_answers = r.answers().len(),
+                            num_authority = r.authority().len(),
+                            num_extra = r.extra().len(),
+                            min_ttl = min_ttl,
+                            elapsed = ?elapsed,
+                        );
+                    }
+                }
+                Err(e) => {
+                    tracing::error!(message = "failed to resolve", name = %name, err = %e);
+                    fatal_errors += 1;
+                }
+            }
+
+            total += 1;
+        }
+
+        let timing = timing_builder.build();
+        Bundle {
+            timing,
+            total,
+            protocol_errors,
+            fatal_errors,
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
+pub struct Bundle {
+    pub timing: Timing,
+    pub total: u64,
+    pub protocol_errors: u64,
+    pub fatal_errors: u64,
+}

--- a/mtop/src/sig.rs
+++ b/mtop/src/sig.rs
@@ -1,0 +1,15 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use tokio::runtime::Handle;
+
+/// Spawn a future that waits for a CTRL-C interrupt (SIGINT on Unix) and
+/// sets the `interrupted` boolean to `true`.
+pub async fn wait_for_interrupt(handle: Handle, interrupted: Arc<AtomicBool>) {
+    handle.spawn(async move {
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {
+                interrupted.store(true, Ordering::Release);
+            }
+        }
+    });
+}


### PR DESCRIPTION
Improvements for `mc bench` and `mc check`:

* Gracefully handle SIGINT, stopping the main loop
* Print summary information even when interrupted
* Change precision of timing output to 6 digits from 9
* Rename "total" time fields to "overall" for clarity
* Compute standard deviation using constant memory
* Simplify benchmarking code

Improvements for `dns ping`:

* Gracefully handle SIGINT, stopping the main loop
* Print summary information event when interrupted
* Support setting the nameserver to use explicitly instead of requiring a custom resolv.conf file