### PR TITLE
Don't attempt to resolve bare hostnames

### DIFF
--- a/mtop/src/bin/mc.rs
+++ b/mtop/src/bin/mc.rs
@@ -297,9 +297,9 @@ async fn main() -> ExitCode {
     let resolver = DiscoveryDefault::new(dns_client);
     let timeout = Duration::from_secs(opts.timeout_secs);
     let servers = match resolver
-        .resolve_by_proto(&opts.host)
-        .timeout(timeout, "resolver.resolve_by_proto")
-        .instrument(tracing::span!(Level::INFO, "resolver.resolve_by_proto"))
+        .resolve(&opts.host)
+        .timeout(timeout, "resolver.resolve")
+        .instrument(tracing::span!(Level::INFO, "resolver.resolve"))
         .await
     {
         Ok(v) => v,

--- a/mtop/src/bin/mtop.rs
+++ b/mtop/src/bin/mtop.rs
@@ -211,9 +211,9 @@ async fn expand_hosts(
     for host in hosts {
         out.extend(
             resolver
-                .resolve_by_proto(host)
-                .timeout(timeout, "resolver.resolve_by_proto")
-                .instrument(tracing::span!(Level::INFO, "resolver.resolve_by_proto"))
+                .resolve(host)
+                .timeout(timeout, "resolver.resolve")
+                .instrument(tracing::span!(Level::INFO, "resolver.resolve"))
                 .await?,
         );
     }

--- a/mtop/src/check.rs
+++ b/mtop/src/check.rs
@@ -64,7 +64,7 @@ impl Checker {
             let dns_start = Instant::now();
             let server = match self
                 .resolver
-                .resolve_by_proto(host)
+                .resolve(host)
                 .timeout(self.timeout, "resolver.resolve_by_proto")
                 .await
                 .map(|mut v| v.pop())


### PR DESCRIPTION
When connecting to Memcached servers, only attempt to resolve the hostnames to IP addresses when prefixed with `dns+`. If just a hostname is supplied, attempt to use it verbatim. This results in a better user experience since we get the benefits of using the system resolver and the expected hostname appears in the UI (instead of its IP).

Fixes #151