### PR TITLE
Refactor DNS and Memcached clients to allow easier testing

### DIFF
--- a/mtop-client/src/core.rs
+++ b/mtop-client/src/core.rs
@@ -1305,7 +1305,7 @@ mod test {
     #[tokio::test]
     async fn test_memcached_ping_success() {
         let (mut rx, mut client) = client!("VERSION 1.6.22\r\n");
-        let _res = client.ping().await.unwrap();
+        client.ping().await.unwrap();
 
         let bytes = rx.recv().await.unwrap();
         let command = String::from_utf8(bytes).unwrap();

--- a/mtop-client/src/lib.rs
+++ b/mtop-client/src/lib.rs
@@ -7,7 +7,7 @@ mod pool;
 mod timeout;
 
 pub use crate::client::{
-    MemcachedClient, MemcachedPool, MemcachedPoolConfig, SelectorRendezvous, ServersResponse, ValuesResponse,
+    MemcachedClient, MemcachedClientConfig, MemcachedFactory, SelectorRendezvous, ServersResponse, ValuesResponse,
 };
 pub use crate::core::{
     ErrorKind, Key, Memcached, Meta, MtopError, ProtocolError, ProtocolErrorKind, Slab, SlabItem, SlabItems, Slabs,
@@ -15,5 +15,5 @@ pub use crate::core::{
 };
 pub use crate::discovery::{DiscoveryDefault, Server, ServerID};
 pub use crate::net::TlsConfig;
-pub use crate::pool::PooledClient;
+pub use crate::pool::{ClientFactory, PooledClient};
 pub use crate::timeout::{Timed, Timeout};

--- a/mtop-client/src/pool.rs
+++ b/mtop-client/src/pool.rs
@@ -1,12 +1,18 @@
 use crate::core::MtopError;
 use std::collections::HashMap;
 use std::fmt;
+use std::future::Future;
 use std::hash::Hash;
 use std::ops::{Deref, DerefMut};
 use tokio::sync::Mutex;
 
-pub(crate) trait ClientFactory<K, V> {
-    async fn make(&self, key: &K) -> Result<V, MtopError>;
+/// Trait used by a client pool for creating new client instances when needed.
+///
+/// Implementations are expected to retain any required configuration for client
+/// instances beyond the identifier for an instance (usually a server address).
+pub trait ClientFactory<K, V> {
+    /// Create a new client instance based on its ID.
+    fn make(&self, key: &K) -> impl Future<Output = Result<V, MtopError>> + Send + Sync;
 }
 
 #[derive(Debug, Clone)]

--- a/mtop/src/bench.rs
+++ b/mtop/src/bench.rs
@@ -1,4 +1,4 @@
-use mtop_client::{MemcachedClient, MtopError, Timeout};
+use mtop_client::{MemcachedClient, MemcachedFactory, MtopError, Timeout};
 use rand::Rng;
 use rand_distr::Exp;
 use std::fmt;
@@ -54,7 +54,7 @@ impl fmt::Display for Percent {
 /// Spawn one or more workers to perform gets and sets against a Memcached server as fast as possible.
 #[derive(Debug)]
 pub struct Bencher {
-    client: Arc<MemcachedClient>,
+    client: Arc<MemcachedClient<MemcachedFactory>>,
     handle: Handle,
     delay: Duration,
     timeout: Duration,
@@ -75,7 +75,7 @@ impl Bencher {
     // STFU clippy
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        client: MemcachedClient,
+        client: MemcachedClient<MemcachedFactory>,
         handle: Handle,
         delay: Duration,
         timeout: Duration,

--- a/mtop/src/check.rs
+++ b/mtop/src/check.rs
@@ -1,4 +1,4 @@
-use mtop_client::{DiscoveryDefault, Key, MemcachedClient, Timeout};
+use mtop_client::{DiscoveryDefault, Key, MemcachedClient, MemcachedFactory, Timeout};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -10,7 +10,7 @@ const VALUE: &[u8] = "test".as_bytes();
 /// Repeatedly make connections to a Memcached server to verify connectivity.
 #[derive(Debug)]
 pub struct Checker {
-    client: MemcachedClient,
+    client: MemcachedClient<MemcachedFactory>,
     resolver: DiscoveryDefault,
     delay: Duration,
     timeout: Duration,
@@ -23,7 +23,7 @@ impl Checker {
     /// part of the test may take (DNS resolution, connecting, setting a value, and fetching
     /// a value).
     pub fn new(
-        client: MemcachedClient,
+        client: MemcachedClient<MemcachedFactory>,
         resolver: DiscoveryDefault,
         delay: Duration,
         timeout: Duration,


### PR DESCRIPTION
* Use pointers to traits for read and write sockets for DNS clients to allow use of alternate implementations and remove generic parameters from each client instance.
* Add generic parameter to `MemcachedClient` to allow use of an alternate factory that doesn't actually create network connections.