### PR TITLE
Add unit tests for MemcachedClient

### DIFF
--- a/mtop-client/src/core.rs
+++ b/mtop-client/src/core.rs
@@ -621,6 +621,12 @@ pub struct ProtocolError {
     message: Option<String>,
 }
 
+impl ProtocolError {
+    pub fn kind(&self) -> ProtocolErrorKind {
+        self.kind
+    }
+}
+
 impl fmt::Display for ProtocolError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(msg) = &self.message {

--- a/mtop-client/src/discovery.rs
+++ b/mtop-client/src/discovery.rs
@@ -69,16 +69,16 @@ impl Server {
         Self { id, name }
     }
 
-    pub fn id(&self) -> ServerID {
-        self.id.clone()
+    pub fn id(&self) -> &ServerID {
+        &self.id
     }
 
-    pub fn server_name(&self) -> ServerName<'static> {
-        self.name.clone()
+    pub fn server_name(&self) -> &ServerName<'static> {
+        &self.name
     }
 
-    pub fn address(&self) -> String {
-        self.id.to_string()
+    pub fn address(&self) -> &str {
+        self.id.as_ref()
     }
 }
 
@@ -90,13 +90,13 @@ impl PartialOrd for Server {
 
 impl Ord for Server {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.id().cmp(&other.id())
+        self.id.cmp(&other.id)
     }
 }
 
 impl fmt::Display for Server {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.id())
+        write!(f, "{}", self.id)
     }
 }
 
@@ -388,7 +388,7 @@ mod test {
         let servers = DiscoveryDefault::resolve_by_proto(&client, "dns+example.com:11211")
             .await
             .unwrap();
-        let ids = servers.iter().map(|s| s.id()).collect::<Vec<_>>();
+        let ids = servers.iter().map(|s| s.id().clone()).collect::<Vec<_>>();
 
         let id_a = ServerID::from(("10.1.1.1", 11211));
         let id_aaaa = ServerID::from(("[::1]", 11211));
@@ -433,7 +433,7 @@ mod test {
         let servers = DiscoveryDefault::resolve_by_proto(&client, "dnssrv+_cache.example.com:11211")
             .await
             .unwrap();
-        let ids = servers.iter().map(|s| s.id()).collect::<Vec<_>>();
+        let ids = servers.iter().map(|s| s.id().clone()).collect::<Vec<_>>();
 
         let id1 = ServerID::from(("cache01.example.com.", 11211));
         let id2 = ServerID::from(("cache02.example.com.", 11211));
@@ -449,7 +449,7 @@ mod test {
 
         let client = MockDnsClient::new(vec![]);
         let servers = DiscoveryDefault::resolve_by_proto(&client, name).await.unwrap();
-        let ids = servers.iter().map(|s| s.id()).collect::<Vec<_>>();
+        let ids = servers.iter().map(|s| s.id().clone()).collect::<Vec<_>>();
 
         let id = ServerID::from(addr);
         assert!(ids.contains(&id), "expected {:?} to contain {:?}", ids, id);
@@ -461,7 +461,7 @@ mod test {
 
         let client = MockDnsClient::new(vec![]);
         let servers = DiscoveryDefault::resolve_by_proto(&client, name).await.unwrap();
-        let ids = servers.iter().map(|s| s.id()).collect::<Vec<_>>();
+        let ids = servers.iter().map(|s| s.id().clone()).collect::<Vec<_>>();
 
         let id = ServerID::from(("localhost", 11211));
         assert!(ids.contains(&id), "expected {:?} to contain {:?}", ids, id);

--- a/mtop-client/src/lib.rs
+++ b/mtop-client/src/lib.rs
@@ -7,7 +7,8 @@ mod pool;
 mod timeout;
 
 pub use crate::client::{
-    MemcachedClient, MemcachedClientConfig, MemcachedFactory, SelectorRendezvous, ServersResponse, ValuesResponse,
+    MemcachedClient, MemcachedClientConfig, MemcachedFactory, Selector, SelectorRendezvous, ServersResponse,
+    ValuesResponse,
 };
 pub use crate::core::{
     ErrorKind, Key, Memcached, Meta, MtopError, ProtocolError, ProtocolErrorKind, Slab, SlabItem, SlabItems, Slabs,

--- a/mtop-client/src/pool.rs
+++ b/mtop-client/src/pool.rs
@@ -25,7 +25,7 @@ pub(crate) struct ClientPoolConfig {
 pub(crate) struct ClientPool<K, V, F>
 where
     K: Eq + Hash + Clone + fmt::Display,
-    F: ClientFactory<K, V>,
+    F: ClientFactory<K, V> + Send + Sync,
 {
     clients: Mutex<HashMap<K, Vec<PooledClient<K, V>>>>,
     config: ClientPoolConfig,
@@ -35,7 +35,7 @@ where
 impl<K, V, F> ClientPool<K, V, F>
 where
     K: Eq + Hash + Clone + fmt::Display,
-    F: ClientFactory<K, V>,
+    F: ClientFactory<K, V> + Send + Sync,
 {
     pub(crate) fn new(config: ClientPoolConfig, factory: F) -> Self {
         Self {

--- a/mtop/src/bench.rs
+++ b/mtop/src/bench.rs
@@ -1,4 +1,4 @@
-use mtop_client::{MemcachedClient, MemcachedFactory, MtopError, Timeout};
+use mtop_client::{MemcachedClient, MemcachedFactory, MtopError, SelectorRendezvous, Timeout};
 use rand::Rng;
 use rand_distr::Exp;
 use std::fmt;
@@ -54,7 +54,7 @@ impl fmt::Display for Percent {
 /// Spawn one or more workers to perform gets and sets against a Memcached server as fast as possible.
 #[derive(Debug)]
 pub struct Bencher {
-    client: Arc<MemcachedClient<MemcachedFactory>>,
+    client: Arc<MemcachedClient<SelectorRendezvous, MemcachedFactory>>,
     handle: Handle,
     delay: Duration,
     timeout: Duration,
@@ -75,7 +75,7 @@ impl Bencher {
     // STFU clippy
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        client: MemcachedClient<MemcachedFactory>,
+        client: MemcachedClient<SelectorRendezvous, MemcachedFactory>,
         handle: Handle,
         delay: Duration,
         timeout: Duration,

--- a/mtop/src/bin/mc.rs
+++ b/mtop/src/bin/mc.rs
@@ -339,7 +339,10 @@ async fn main() -> ExitCode {
     code
 }
 
-async fn new_client(opts: &McConfig, servers: &[Server]) -> Result<MemcachedClient<MemcachedFactory>, MtopError> {
+async fn new_client(
+    opts: &McConfig,
+    servers: &[Server],
+) -> Result<MemcachedClient<SelectorRendezvous, MemcachedFactory>, MtopError> {
     let tls_config = TlsConfig {
         enabled: opts.tls_enabled,
         ca_path: opts.tls_ca.clone(),
@@ -357,7 +360,10 @@ async fn new_client(opts: &McConfig, servers: &[Server]) -> Result<MemcachedClie
     Ok(MemcachedClient::new(cfg, Handle::current(), selector, factory))
 }
 
-async fn connect(client: &MemcachedClient<MemcachedFactory>, timeout: Duration) -> Result<(), MtopError> {
+async fn connect(
+    client: &MemcachedClient<SelectorRendezvous, MemcachedFactory>,
+    timeout: Duration,
+) -> Result<(), MtopError> {
     let pings = client
         .ping()
         .timeout(timeout, "client.ping")
@@ -371,7 +377,11 @@ async fn connect(client: &MemcachedClient<MemcachedFactory>, timeout: Duration) 
     Ok(())
 }
 
-async fn run_add(opts: &McConfig, cmd: &AddCommand, client: &MemcachedClient<MemcachedFactory>) -> ExitCode {
+async fn run_add(
+    opts: &McConfig,
+    cmd: &AddCommand,
+    client: &MemcachedClient<SelectorRendezvous, MemcachedFactory>,
+) -> ExitCode {
     let buf = match read_input().await {
         Ok(v) => v,
         Err(e) => {
@@ -393,7 +403,11 @@ async fn run_add(opts: &McConfig, cmd: &AddCommand, client: &MemcachedClient<Mem
     }
 }
 
-async fn run_bench(opts: &McConfig, cmd: &BenchCommand, client: MemcachedClient<MemcachedFactory>) -> ExitCode {
+async fn run_bench(
+    opts: &McConfig,
+    cmd: &BenchCommand,
+    client: MemcachedClient<SelectorRendezvous, MemcachedFactory>,
+) -> ExitCode {
     let stop = Arc::new(AtomicBool::new(false));
     mtop::sig::wait_for_interrupt(Handle::current(), stop.clone()).await;
 
@@ -417,7 +431,7 @@ async fn run_bench(opts: &McConfig, cmd: &BenchCommand, client: MemcachedClient<
 async fn run_check(
     opts: &McConfig,
     cmd: &CheckCommand,
-    client: MemcachedClient<MemcachedFactory>,
+    client: MemcachedClient<SelectorRendezvous, MemcachedFactory>,
     resolver: DiscoveryDefault,
 ) -> ExitCode {
     let stop = Arc::new(AtomicBool::new(false));
@@ -440,7 +454,11 @@ async fn run_check(
     }
 }
 
-async fn run_decr(opts: &McConfig, cmd: &DecrCommand, client: &MemcachedClient<MemcachedFactory>) -> ExitCode {
+async fn run_decr(
+    opts: &McConfig,
+    cmd: &DecrCommand,
+    client: &MemcachedClient<SelectorRendezvous, MemcachedFactory>,
+) -> ExitCode {
     if let Err(e) = client
         .decr(&cmd.key, cmd.delta)
         .timeout(Duration::from_secs(opts.timeout_secs), "client.decr")
@@ -454,7 +472,11 @@ async fn run_decr(opts: &McConfig, cmd: &DecrCommand, client: &MemcachedClient<M
     }
 }
 
-async fn run_delete(opts: &McConfig, cmd: &DeleteCommand, client: &MemcachedClient<MemcachedFactory>) -> ExitCode {
+async fn run_delete(
+    opts: &McConfig,
+    cmd: &DeleteCommand,
+    client: &MemcachedClient<SelectorRendezvous, MemcachedFactory>,
+) -> ExitCode {
     if let Err(e) = client
         .delete(&cmd.key)
         .timeout(Duration::from_secs(opts.timeout_secs), "client.delete")
@@ -468,7 +490,11 @@ async fn run_delete(opts: &McConfig, cmd: &DeleteCommand, client: &MemcachedClie
     }
 }
 
-async fn run_get(opts: &McConfig, cmd: &GetCommand, client: &MemcachedClient<MemcachedFactory>) -> ExitCode {
+async fn run_get(
+    opts: &McConfig,
+    cmd: &GetCommand,
+    client: &MemcachedClient<SelectorRendezvous, MemcachedFactory>,
+) -> ExitCode {
     let response = match client
         .get(&[cmd.key.clone()])
         .timeout(Duration::from_secs(opts.timeout_secs), "client.get")
@@ -499,7 +525,11 @@ async fn run_get(opts: &McConfig, cmd: &GetCommand, client: &MemcachedClient<Mem
     }
 }
 
-async fn run_incr(opts: &McConfig, cmd: &IncrCommand, client: &MemcachedClient<MemcachedFactory>) -> ExitCode {
+async fn run_incr(
+    opts: &McConfig,
+    cmd: &IncrCommand,
+    client: &MemcachedClient<SelectorRendezvous, MemcachedFactory>,
+) -> ExitCode {
     if let Err(e) = client
         .incr(&cmd.key, cmd.delta)
         .timeout(Duration::from_secs(opts.timeout_secs), "client.incr")
@@ -513,7 +543,11 @@ async fn run_incr(opts: &McConfig, cmd: &IncrCommand, client: &MemcachedClient<M
     }
 }
 
-async fn run_keys(opts: &McConfig, cmd: &KeysCommand, client: &MemcachedClient<MemcachedFactory>) -> ExitCode {
+async fn run_keys(
+    opts: &McConfig,
+    cmd: &KeysCommand,
+    client: &MemcachedClient<SelectorRendezvous, MemcachedFactory>,
+) -> ExitCode {
     let response = match client
         .metas()
         .timeout(Duration::from_secs(opts.timeout_secs), "client.metas")
@@ -546,7 +580,11 @@ async fn run_keys(opts: &McConfig, cmd: &KeysCommand, client: &MemcachedClient<M
     }
 }
 
-async fn run_replace(opts: &McConfig, cmd: &ReplaceCommand, client: &MemcachedClient<MemcachedFactory>) -> ExitCode {
+async fn run_replace(
+    opts: &McConfig,
+    cmd: &ReplaceCommand,
+    client: &MemcachedClient<SelectorRendezvous, MemcachedFactory>,
+) -> ExitCode {
     let buf = match read_input().await {
         Ok(v) => v,
         Err(e) => {
@@ -568,7 +606,11 @@ async fn run_replace(opts: &McConfig, cmd: &ReplaceCommand, client: &MemcachedCl
     }
 }
 
-async fn run_set(opts: &McConfig, cmd: &SetCommand, client: &MemcachedClient<MemcachedFactory>) -> ExitCode {
+async fn run_set(
+    opts: &McConfig,
+    cmd: &SetCommand,
+    client: &MemcachedClient<SelectorRendezvous, MemcachedFactory>,
+) -> ExitCode {
     let buf = match read_input().await {
         Ok(v) => v,
         Err(e) => {
@@ -590,7 +632,11 @@ async fn run_set(opts: &McConfig, cmd: &SetCommand, client: &MemcachedClient<Mem
     }
 }
 
-async fn run_touch(opts: &McConfig, cmd: &TouchCommand, client: &MemcachedClient<MemcachedFactory>) -> ExitCode {
+async fn run_touch(
+    opts: &McConfig,
+    cmd: &TouchCommand,
+    client: &MemcachedClient<SelectorRendezvous, MemcachedFactory>,
+) -> ExitCode {
     if let Err(e) = client
         .touch(&cmd.key, cmd.ttl)
         .timeout(Duration::from_secs(opts.timeout_secs), "client.touch")

--- a/mtop/src/check.rs
+++ b/mtop/src/check.rs
@@ -1,4 +1,4 @@
-use mtop_client::{DiscoveryDefault, Key, MemcachedClient, MemcachedFactory, Timeout};
+use mtop_client::{DiscoveryDefault, Key, MemcachedClient, MemcachedFactory, SelectorRendezvous, Timeout};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -10,7 +10,7 @@ const VALUE: &[u8] = "test".as_bytes();
 /// Repeatedly make connections to a Memcached server to verify connectivity.
 #[derive(Debug)]
 pub struct Checker {
-    client: MemcachedClient<MemcachedFactory>,
+    client: MemcachedClient<SelectorRendezvous, MemcachedFactory>,
     resolver: DiscoveryDefault,
     delay: Duration,
     timeout: Duration,
@@ -23,7 +23,7 @@ impl Checker {
     /// part of the test may take (DNS resolution, connecting, setting a value, and fetching
     /// a value).
     pub fn new(
-        client: MemcachedClient<MemcachedFactory>,
+        client: MemcachedClient<SelectorRendezvous, MemcachedFactory>,
         resolver: DiscoveryDefault,
         delay: Duration,
         timeout: Duration,

--- a/mtop/src/queue.rs
+++ b/mtop/src/queue.rs
@@ -10,7 +10,7 @@ use tokio::sync::Mutex;
 pub struct Host(String);
 
 impl Host {
-    pub fn from(id: ServerID) -> Self {
+    pub fn from(id: &ServerID) -> Self {
         Self(id.to_string())
     }
 }


### PR DESCRIPTION
Refactor MemcachedClient to make it unit testable and then add tests of a few representative methods. This change makes extracts the `Selector` logic for picking a server based on key to a trait and makes that type generic in the client. This is more verbose but allows us to use custom selector logic in the unit tests.