### PR TITLE
Add defaults for MemcachedClient generic parameters

### DIFF
--- a/mtop-client/src/lib.rs
+++ b/mtop-client/src/lib.rs
@@ -7,8 +7,7 @@ mod pool;
 mod timeout;
 
 pub use crate::client::{
-    MemcachedClient, MemcachedClientConfig, MemcachedFactory, Selector, SelectorRendezvous, ServersResponse,
-    ValuesResponse,
+    MemcachedClient, MemcachedClientConfig, Selector, SelectorRendezvous, ServersResponse, TcpFactory, ValuesResponse,
 };
 pub use crate::core::{
     ErrorKind, Key, Memcached, Meta, MtopError, ProtocolError, ProtocolErrorKind, Slab, SlabItem, SlabItems, Slabs,

--- a/mtop/src/bench.rs
+++ b/mtop/src/bench.rs
@@ -1,4 +1,4 @@
-use mtop_client::{MemcachedClient, MemcachedFactory, MtopError, SelectorRendezvous, Timeout};
+use mtop_client::{MemcachedClient, MtopError, Timeout};
 use rand::Rng;
 use rand_distr::Exp;
 use std::fmt;
@@ -54,7 +54,7 @@ impl fmt::Display for Percent {
 /// Spawn one or more workers to perform gets and sets against a Memcached server as fast as possible.
 #[derive(Debug)]
 pub struct Bencher {
-    client: Arc<MemcachedClient<SelectorRendezvous, MemcachedFactory>>,
+    client: Arc<MemcachedClient>,
     handle: Handle,
     delay: Duration,
     timeout: Duration,
@@ -75,7 +75,7 @@ impl Bencher {
     // STFU clippy
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        client: MemcachedClient<SelectorRendezvous, MemcachedFactory>,
+        client: MemcachedClient,
         handle: Handle,
         delay: Duration,
         timeout: Duration,

--- a/mtop/src/check.rs
+++ b/mtop/src/check.rs
@@ -1,4 +1,4 @@
-use mtop_client::{DiscoveryDefault, Key, MemcachedClient, MemcachedFactory, SelectorRendezvous, Timeout};
+use mtop_client::{DiscoveryDefault, Key, MemcachedClient, Timeout};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -10,7 +10,7 @@ const VALUE: &[u8] = "test".as_bytes();
 /// Repeatedly make connections to a Memcached server to verify connectivity.
 #[derive(Debug)]
 pub struct Checker {
-    client: MemcachedClient<SelectorRendezvous, MemcachedFactory>,
+    client: MemcachedClient,
     resolver: DiscoveryDefault,
     delay: Duration,
     timeout: Duration,
@@ -23,7 +23,7 @@ impl Checker {
     /// part of the test may take (DNS resolution, connecting, setting a value, and fetching
     /// a value).
     pub fn new(
-        client: MemcachedClient<SelectorRendezvous, MemcachedFactory>,
+        client: MemcachedClient,
         resolver: DiscoveryDefault,
         delay: Duration,
         timeout: Duration,


### PR DESCRIPTION
Default to using `SelectorRendezvous` for the selector implementation and `TcpFactory` for the client factory implementation since this is what most consumers of the client use. Non-defaults are only used for unit tests.