### PR TITLE
Make DNS client used by server discovery generic

### DIFF
--- a/mtop-client/src/client.rs
+++ b/mtop-client/src/client.rs
@@ -64,11 +64,11 @@ pub trait Selector {
 ///
 /// See https://en.wikipedia.org/wiki/Rendezvous_hashing
 #[derive(Debug)]
-pub struct SelectorRendezvous {
+pub struct RendezvousSelector {
     servers: Vec<Server>,
 }
 
-impl SelectorRendezvous {
+impl RendezvousSelector {
     /// Create a new instance with the provided initial server list.
     pub fn new(servers: Vec<Server>) -> Self {
         Self { servers }
@@ -82,7 +82,7 @@ impl SelectorRendezvous {
     }
 }
 
-impl Selector for SelectorRendezvous {
+impl Selector for RendezvousSelector {
     async fn servers(&self) -> Vec<Server> {
         self.servers.clone()
     }
@@ -223,7 +223,7 @@ impl Default for MemcachedClientConfig {
 /// Memcached client that operates on multiple servers, pooling connections
 /// to them, and sharding keys via a `Selector` implementation.
 #[derive(Debug)]
-pub struct MemcachedClient<S = SelectorRendezvous, F = TcpFactory>
+pub struct MemcachedClient<S = RendezvousSelector, F = TcpFactory>
 where
     S: Selector + Send + Sync + 'static,
     F: ClientFactory<Server, Memcached> + Send + Sync + 'static,

--- a/mtop-client/src/dns/mod.rs
+++ b/mtop-client/src/dns/mod.rs
@@ -5,7 +5,7 @@ mod name;
 mod rdata;
 mod resolv;
 
-pub use crate::dns::client::{DnsClient, DnsClientConfig};
+pub use crate::dns::client::{DefaultDnsClient, DnsClient, DnsClientConfig};
 pub use crate::dns::core::{RecordClass, RecordType};
 pub use crate::dns::message::{Flags, Message, MessageId, Operation, Question, Record, ResponseCode};
 pub use crate::dns::name::Name;

--- a/mtop-client/src/lib.rs
+++ b/mtop-client/src/lib.rs
@@ -7,13 +7,13 @@ mod pool;
 mod timeout;
 
 pub use crate::client::{
-    MemcachedClient, MemcachedClientConfig, Selector, SelectorRendezvous, ServersResponse, TcpFactory, ValuesResponse,
+    MemcachedClient, MemcachedClientConfig, RendezvousSelector, Selector, ServersResponse, TcpFactory, ValuesResponse,
 };
 pub use crate::core::{
     ErrorKind, Key, Memcached, Meta, MtopError, ProtocolError, ProtocolErrorKind, Slab, SlabItem, SlabItems, Slabs,
     Stats, Value,
 };
-pub use crate::discovery::{DiscoveryDefault, Server, ServerID};
+pub use crate::discovery::{Discovery, Server, ServerID};
 pub use crate::net::TlsConfig;
 pub use crate::pool::{ClientFactory, PooledClient};
 pub use crate::timeout::{Timed, Timeout};

--- a/mtop/src/bin/dns.rs
+++ b/mtop/src/bin/dns.rs
@@ -1,7 +1,7 @@
 use clap::{Args, Parser, Subcommand, ValueHint};
 use mtop::ping::{Bundle, DnsPinger};
 use mtop::{profile, sig};
-use mtop_client::dns::{Flags, Message, MessageId, Name, Question, Record, RecordClass, RecordType};
+use mtop_client::dns::{DnsClient, Flags, Message, MessageId, Name, Question, Record, RecordClass, RecordType};
 use std::fmt::Write;
 use std::io::Cursor;
 use std::net::SocketAddr;

--- a/mtop/src/check.rs
+++ b/mtop/src/check.rs
@@ -1,4 +1,4 @@
-use mtop_client::{DiscoveryDefault, Key, MemcachedClient, Timeout};
+use mtop_client::{Discovery, Key, MemcachedClient, Timeout};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -11,7 +11,7 @@ const VALUE: &[u8] = "test".as_bytes();
 #[derive(Debug)]
 pub struct Checker {
     client: MemcachedClient,
-    resolver: DiscoveryDefault,
+    resolver: Discovery,
     delay: Duration,
     timeout: Duration,
     stop: Arc<AtomicBool>,
@@ -24,7 +24,7 @@ impl Checker {
     /// a value).
     pub fn new(
         client: MemcachedClient,
-        resolver: DiscoveryDefault,
+        resolver: Discovery,
         delay: Duration,
         timeout: Duration,
         stop: Arc<AtomicBool>,
@@ -64,7 +64,7 @@ impl Checker {
             let dns_start = Instant::now();
             let server = match self
                 .resolver
-                .resolve(host)
+                .resolve_by_proto(host)
                 .timeout(self.timeout, "resolver.resolve_by_proto")
                 .await
                 .map(|mut v| v.pop())

--- a/mtop/src/dns.rs
+++ b/mtop/src/dns.rs
@@ -1,4 +1,4 @@
-use mtop_client::dns::{DnsClient, DnsClientConfig, ResolvConf};
+use mtop_client::dns::{DefaultDnsClient, DnsClientConfig, ResolvConf};
 use mtop_client::MtopError;
 use std::fmt;
 use std::net::SocketAddr;
@@ -9,7 +9,7 @@ use tokio::fs::File;
 /// Load configuration from the provided resolv.conf file and create a new DnsClient
 /// based on it. If the resolv.conf file cannot be opened or is malformed, default
 /// configuration values will be used. See `man 5 resolv.conf` for more information.
-pub async fn new_client<P>(resolv: P, nameserver: Option<SocketAddr>, timeout: Option<Duration>) -> DnsClient
+pub async fn new_client<P>(resolv: P, nameserver: Option<SocketAddr>, timeout: Option<Duration>) -> DefaultDnsClient
 where
     P: AsRef<Path> + fmt::Debug,
 {
@@ -44,7 +44,7 @@ where
         client_config.timeout = t;
     }
 
-    DnsClient::new(client_config)
+    DefaultDnsClient::new(client_config)
 }
 
 async fn load_config<P>(resolv: P) -> Result<ResolvConf, MtopError>

--- a/mtop/src/ping.rs
+++ b/mtop/src/ping.rs
@@ -1,5 +1,5 @@
 use crate::check::{Timing, TimingBuilder};
-use mtop_client::dns::{DnsClient, Name, RecordClass, RecordType, ResponseCode};
+use mtop_client::dns::{DefaultDnsClient, DnsClient, Name, RecordClass, RecordType, ResponseCode};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -9,7 +9,7 @@ use tracing::{Instrument, Level};
 /// Repeatedly make DNS requests to resolve a domain name.
 #[derive(Debug)]
 pub struct DnsPinger {
-    client: DnsClient,
+    client: DefaultDnsClient,
     interval: Duration,
     stop: Arc<AtomicBool>,
 }
@@ -17,7 +17,7 @@ pub struct DnsPinger {
 impl DnsPinger {
     /// Create a new `DnsPinger` that uses the provided client to repeatedly resolve a domain
     /// name. `interval` is the amount of time to wait between each DNS query.
-    pub fn new(client: DnsClient, interval: Duration, stop: Arc<AtomicBool>) -> Self {
+    pub fn new(client: DefaultDnsClient, interval: Duration, stop: Arc<AtomicBool>) -> Self {
         Self { client, interval, stop }
     }
 


### PR DESCRIPTION
Make the DNS client used by `Discovery` a generic parameter to make testing easier. This also makes the trait for the DNS client public since it must be created by the caller.