### PR TITLE
Make DefaultDnsClient generic for easier testing

### DIFF
--- a/mtop-client/src/dns/message.rs
+++ b/mtop-client/src/dns/message.rs
@@ -102,10 +102,10 @@ impl Message {
     }
 
     fn header(&self) -> Header {
-        assert!(self.questions.len() < u16::MAX as usize);
-        assert!(self.answers.len() < u16::MAX as usize);
-        assert!(self.authority.len() < u16::MAX as usize);
-        assert!(self.extra.len() < u16::MAX as usize);
+        assert!(self.questions.len() < usize::from(u16::MAX));
+        assert!(self.answers.len() < usize::from(u16::MAX));
+        assert!(self.authority.len() < usize::from(u16::MAX));
+        assert!(self.extra.len() < usize::from(u16::MAX));
 
         Header {
             id: self.id,

--- a/mtop-client/src/dns/mod.rs
+++ b/mtop-client/src/dns/mod.rs
@@ -5,7 +5,10 @@ mod name;
 mod rdata;
 mod resolv;
 
-pub use crate::dns::client::{DefaultDnsClient, DnsClient, DnsClientConfig};
+pub use crate::dns::client::{
+    DefaultDnsClient, DnsClient, DnsClientConfig, TcpConnection, TcpConnectionFactory, UdpConnection,
+    UdpConnectionFactory,
+};
 pub use crate::dns::core::{RecordClass, RecordType};
 pub use crate::dns::message::{Flags, Message, MessageId, Operation, Question, Record, ResponseCode};
 pub use crate::dns::name::Name;

--- a/mtop-client/src/test.rs
+++ b/mtop-client/src/test.rs
@@ -3,12 +3,11 @@ use std::future::Future;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter};
-use tokio::net::{TcpListener, TcpStream, ToSocketAddrs};
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader, BufWriter};
+use tokio::net::{TcpListener, ToSocketAddrs};
 use tokio::runtime::Handle;
 use tokio_rustls::rustls::server::WebPkiClientVerifier;
 use tokio_rustls::rustls::ServerConfig;
-use tokio_rustls::server::TlsStream;
 use tokio_rustls::TlsAcceptor;
 
 const RESPONSE_VERSION: &str = "VERSION 1.6.22\r\n";
@@ -68,7 +67,10 @@ where
     })
 }
 
-async fn handle_client_connection(stream: TlsStream<TcpStream>) {
+async fn handle_client_connection<S>(stream: S)
+where
+    S: AsyncRead + AsyncWrite,
+{
     let (read, write) = tokio::io::split(stream);
     let mut read = BufReader::new(read).lines();
     let mut write = BufWriter::new(write);

--- a/mtop/src/dns.rs
+++ b/mtop/src/dns.rs
@@ -44,7 +44,9 @@ where
         client_config.timeout = t;
     }
 
-    DefaultDnsClient::new(client_config)
+    // Use default instances of the UDP and TCP connection factories, alternate
+    // implementations are only useful for unit testing.
+    DefaultDnsClient::new(client_config, Default::default(), Default::default())
 }
 
 async fn load_config<P>(resolv: P) -> Result<ResolvConf, MtopError>


### PR DESCRIPTION
Make the UDP and TCP client factories generic parameters for the DNS client to allow them to be replaced for unit testing. This change also renames the UDP and TCP "clients" to "connections" to emphasize that they are low level and just send messages back and forth.