### PR TITLE
dns: Fix an issue where a buffer was incorrectly reused

### DIFF
--- a/mtop-client/src/dns/core.rs
+++ b/mtop-client/src/dns/core.rs
@@ -17,6 +17,12 @@ pub enum RecordType {
     Unknown(u16),
 }
 
+impl RecordType {
+    pub fn size(&self) -> usize {
+        2
+    }
+}
+
 impl From<u16> for RecordType {
     fn from(value: u16) -> Self {
         match value {
@@ -93,6 +99,12 @@ pub enum RecordClass {
     NONE,
     ANY,
     Unknown(u16),
+}
+
+impl RecordClass {
+    pub fn size(&self) -> usize {
+        2
+    }
 }
 
 impl From<u16> for RecordClass {


### PR DESCRIPTION
Fix an issue with the TCP DNS client where a buffer was not cleared between reuse resulting in TCP connections only being used for a single request and discarded (due to corrupt messages).