### PR TITLE
Preallocate vec for multiple keys

### DIFF
--- a/mtop-client/src/core.rs
+++ b/mtop-client/src/core.rs
@@ -1021,8 +1021,11 @@ impl Key {
         I: IntoIterator<Item = T>,
         T: Into<String>,
     {
-        let mut out = Vec::new();
-        for val in vals {
+        let iter = vals.into_iter();
+        let (sz, _) = iter.size_hint();
+        let mut out = Vec::with_capacity(sz);
+
+        for val in iter {
             out.push(Self::one(val)?);
         }
 

--- a/mtop/src/bench.rs
+++ b/mtop/src/bench.rs
@@ -117,7 +117,8 @@ impl Bencher {
                 let mut stats = Summary {  worker, ..Default::default() };
 
                 while !stop.load(Ordering::Acquire) && start.elapsed() < time {
-                    let set_start = interval.tick().await;
+                    let _ = interval.tick().await;
+                    let set_start = Instant::now();
 
                     for kv in fixture.kvs.iter() {
                         // Write a small percentage of fixture data because cache workloads skew read heavy.


### PR DESCRIPTION
When converting multiple strings to keys, allocate the vec for the keys ahead of time to avoid needing to grow the vec multiple times.

Additionally, fix the timing of `set`s for the `mc bench` command.