### PR TITLE
client: Introduce ServerAddress type

### DIFF
--- a/mtop-client/src/lib.rs
+++ b/mtop-client/src/lib.rs
@@ -17,7 +17,7 @@ pub use crate::core::{
     ErrorKind, Key, Memcached, Meta, MtopError, ProtocolError, ProtocolErrorKind, Slab, SlabItem, SlabItems, Slabs,
     Stats, Value,
 };
-pub use crate::discovery::{Discovery, Server, ServerID};
+pub use crate::discovery::{Discovery, Server, ServerAddress, ServerID};
 pub use crate::net::TlsConfig;
 pub use crate::pool::{ClientFactory, PooledClient};
 pub use crate::timeout::{Timed, Timeout};

--- a/mtop-client/src/net/mod.rs
+++ b/mtop-client/src/net/mod.rs
@@ -1,0 +1,6 @@
+mod tcp;
+mod tls;
+
+pub(crate) use crate::net::tcp::{tcp_connect, tcp_tls_connect};
+pub use crate::net::tls::TlsConfig;
+pub(crate) use crate::net::tls::{custom_root_store, default_root_store, load_cert, load_key, tls_client_config};

--- a/mtop-client/src/net/tcp.rs
+++ b/mtop-client/src/net/tcp.rs
@@ -1,0 +1,43 @@
+use crate::core::MtopError;
+use rustls_pki_types::ServerName;
+use std::fmt;
+use std::sync::Arc;
+use tokio::io::{ReadHalf, WriteHalf};
+use tokio::net::{TcpStream, ToSocketAddrs};
+use tokio_rustls::client::TlsStream;
+use tokio_rustls::rustls::ClientConfig;
+use tokio_rustls::TlsConnector;
+
+pub(crate) async fn tcp_connect<A>(host: A) -> Result<(ReadHalf<TcpStream>, WriteHalf<TcpStream>), MtopError>
+where
+    A: ToSocketAddrs + fmt::Display,
+{
+    let tcp_stream = tcp_stream(host).await?;
+    Ok(tokio::io::split(tcp_stream))
+}
+
+pub(crate) async fn tcp_tls_connect<A>(
+    host: A,
+    server: ServerName<'static>,
+    config: Arc<ClientConfig>,
+) -> Result<(ReadHalf<TlsStream<TcpStream>>, WriteHalf<TlsStream<TcpStream>>), MtopError>
+where
+    A: ToSocketAddrs + fmt::Display,
+{
+    let tcp_stream = tcp_stream(host).await?;
+    let connector = TlsConnector::from(config);
+    let tls_stream = connector.connect(server, tcp_stream).await?;
+    Ok(tokio::io::split(tls_stream))
+}
+
+async fn tcp_stream<A>(host: A) -> Result<TcpStream, MtopError>
+where
+    A: ToSocketAddrs + fmt::Display,
+{
+    TcpStream::connect(&host)
+        .await
+        // The client buffers and flushes writes so we don't need delay here to
+        // avoid lots of tiny packets.
+        .and_then(|s| s.set_nodelay(true).map(|_| s))
+        .map_err(|e| MtopError::from((host.to_string(), e)))
+}

--- a/mtop-client/tests/tls.rs
+++ b/mtop-client/tests/tls.rs
@@ -1,7 +1,7 @@
 use mtop_client::test::{tls_server, TlsServerConfig};
 use mtop_client::{
-    MemcachedClient, MemcachedClientConfig, RendezvousSelector, Server, ServerID, ServersResponse, TcpClientFactory,
-    TlsConfig,
+    MemcachedClient, MemcachedClientConfig, RendezvousSelector, Server, ServerAddress, ServerID, ServersResponse,
+    TcpClientFactory, TlsConfig,
 };
 use rustls_pki_types::ServerName;
 use std::path::PathBuf;
@@ -20,6 +20,7 @@ async fn run_server(server_config: TlsServerConfig, client_config: TlsConfig) ->
     let factory = TcpClientFactory::new(client_config, Handle::current()).await.unwrap();
     let selector = RendezvousSelector::new(vec![Server::new(
         server_id.clone(),
+        ServerAddress::from(addr),
         ServerName::try_from("localhost").unwrap(),
     )]);
 


### PR DESCRIPTION
Instead of relying on different types of strings to represent the address of each server (IP addresses, hostnames) use an enum with variants for sockets or hostnames. This allows us to extend the type with paths for UNIX sockets in the future.

Related https://github.com/56quarters/mtop/issues/191