### PR TITLE
fix: Only create ServerAddress from host _and_ port

### DIFF
--- a/mtop-client/src/client.rs
+++ b/mtop-client/src/client.rs
@@ -580,7 +580,7 @@ mod test {
                 let (host, port_str) = $host_and_port.split_once(':').unwrap();
                 let port: u16 = port_str.parse().unwrap();
                 let id = ServerID::from((host, port));
-                let addr = ServerAddress::from($host_and_port);
+                let addr = ServerAddress::from((host, port));
                 let name = ServerName::try_from(host).unwrap();
 
                 Server::new(id, addr, name)


### PR DESCRIPTION
Fix an issue where `ServerAddress` instances were sometimes created only from a hostname which could not be used to connect to a server.