### PR TITLE
Use `rustls-pki-types` for TLS PEM parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,12 +63,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,7 +417,6 @@ dependencies = [
  "byteorder",
  "pin-project-lite",
  "rand",
- "rustls-pemfile",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -709,20 +702,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
-dependencies = [
- "base64",
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
-version = "1.7.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 
 [[package]]
 name = "rustls-webpki"

--- a/mtop-client/Cargo.toml
+++ b/mtop-client/Cargo.toml
@@ -14,8 +14,7 @@ edition = "2021"
 byteorder = "1.5.0"
 pin-project-lite = "0.2.13"
 rand = "0.8.5"
-rustls-pemfile = "2.1.0"
-rustls-pki-types = "1.7.0"
+rustls-pki-types = {  version = "1.11.0", features = ["std"]}
 tokio = { version = "1.36.0", features = ["full"] }
 tokio-rustls = { version = "0.26.0", default-features = false, features = ["ring", "tls12"] }
 tracing = "0.1.40"


### PR DESCRIPTION
Remove dependency on rustls-pemfile since we are already using the rustls-pki-types crate