### PR TITLE
client: Unify ServerID and ServerAddress types

### DIFF
--- a/mtop-client/src/lib.rs
+++ b/mtop-client/src/lib.rs
@@ -17,7 +17,7 @@ pub use crate::core::{
     ErrorKind, Key, Memcached, Meta, MtopError, ProtocolError, ProtocolErrorKind, Slab, SlabItem, SlabItems, Slabs,
     Stats, Value,
 };
-pub use crate::discovery::{Discovery, Server, ServerAddress, ServerID};
+pub use crate::discovery::{Discovery, Server, ServerID};
 pub use crate::net::TlsConfig;
 pub use crate::pool::{ClientFactory, PooledClient};
 pub use crate::timeout::{Timed, Timeout};

--- a/mtop-client/tests/tls.rs
+++ b/mtop-client/tests/tls.rs
@@ -1,7 +1,7 @@
 use mtop_client::test::{tls_server, TlsServerConfig};
 use mtop_client::{
-    MemcachedClient, MemcachedClientConfig, RendezvousSelector, Server, ServerAddress, ServerID, ServersResponse,
-    TcpClientFactory, TlsConfig,
+    MemcachedClient, MemcachedClientConfig, RendezvousSelector, Server, ServerID, ServersResponse, TcpClientFactory,
+    TlsConfig,
 };
 use rustls_pki_types::ServerName;
 use std::path::PathBuf;
@@ -14,13 +14,12 @@ fn test_path(p: &str) -> PathBuf {
 /// Start a stub server, connect to it using TLS, and run the `ping` method from the client against it.
 async fn run_server(server_config: TlsServerConfig, client_config: TlsConfig) -> (ServerID, ServersResponse<()>) {
     let (addr, server) = tls_server(server_config, Handle::current(), "localhost:0").await;
-    let server_id = ServerID::from(addr);
+    let id = ServerID::from(addr);
     let handle = tokio::spawn(server);
 
     let factory = TcpClientFactory::new(client_config, Handle::current()).await.unwrap();
     let selector = RendezvousSelector::new(vec![Server::new(
-        server_id.clone(),
-        ServerAddress::from(addr),
+        id.clone(),
         ServerName::try_from("localhost").unwrap(),
     )]);
 
@@ -29,7 +28,7 @@ async fn run_server(server_config: TlsServerConfig, client_config: TlsConfig) ->
     let res = client.ping().await.unwrap();
     handle.abort();
 
-    (server_id, res)
+    (id, res)
 }
 
 #[tokio::test]

--- a/mtop/src/check.rs
+++ b/mtop/src/check.rs
@@ -89,7 +89,7 @@ impl Checker {
             let mut conn = match self.client.raw_open(&server).timeout(self.timeout, "client.raw_open").await {
                 Ok(v) => v,
                 Err(e) => {
-                    tracing::warn!(message = "failed to connect to host", host = host, addr = %server.address(), err = %e);
+                    tracing::warn!(message = "failed to connect to host", host = host, addr = %server.id(), err = %e);
                     failures.total += 1;
                     failures.connections += 1;
                     continue;
@@ -101,7 +101,7 @@ impl Checker {
             match conn.set(&key, 0, 60, &val).timeout(self.timeout, "connection.set").await {
                 Ok(_) => {}
                 Err(e) => {
-                    tracing::warn!(message = "failed to set key", host = host, addr = %server.address(), err = %e);
+                    tracing::warn!(message = "failed to set key", host = host, addr = %server.id(), err = %e);
                     failures.total += 1;
                     failures.sets += 1;
                     continue;
@@ -113,7 +113,7 @@ impl Checker {
             match conn.get(&[key]).timeout(self.timeout, "connection.get").await {
                 Ok(_) => {}
                 Err(e) => {
-                    tracing::warn!(message = "failed to get key", host = host, addr = %server.address(), err = %e);
+                    tracing::warn!(message = "failed to get key", host = host, addr = %server.id(), err = %e);
                     failures.total += 1;
                     failures.gets += 1;
                     continue;


### PR DESCRIPTION
Replace `ServerID` implementation with `ServerAddress` since they ended up with nearly identical code. The new `ServerID` now acts as both the unique ID for a server and the address needed to connect to it.