### PR TITLE
dns: Refactor `Name` parsing to improve performance

### DIFF
--- a/mtop-client/src/core.rs
+++ b/mtop-client/src/core.rs
@@ -1074,7 +1074,7 @@ impl Key {
 
 impl fmt::Display for Key {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+        self.0.fmt(f)
     }
 }
 


### PR DESCRIPTION
Refactor DNS `Name` parsing code to avoid unnecessary conversions to strings. This results in between 15 and 20% improvement in benchmarks.