### PR TITLE
tests: Introduce fuzz testing and fix issues identified

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +154,8 @@ version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -407,6 +418,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,6 +529,16 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fuzz"
+version = "0.0.0"
+dependencies = [
+ "libfuzzer-sys",
+ "mtop-client",
+ "tokio",
+ "urlencoding",
+]
 
 [[package]]
 name = "getrandom"
@@ -650,6 +682,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jobserver"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+dependencies = [
+ "getrandom 0.3.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,6 +712,16 @@ name = "libc"
 version = "0.2.173"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8cfeafaffdbc32176b64fb251369d52ea9f0a8fbc6f8759edffef7b525d64bb"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf78f52d400cf2d84a3a973a78a592b4adc535739e0a5597a0da6f0c357adc75"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
 
 [[package]]
 name = "libm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,8 @@ members = [
   "mtop-client",
 
   # Internal
-  "benches"
+  "benches",
+  "fuzz",
 ]
 
 # Config for 'cargo dist'

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -2,12 +2,12 @@
 name = "benches"
 version = "0.0.0"
 publish = false
-edition = "2021"
+edition = "2024"
 license = "GPL-3.0+"
 
 [dependencies]
-mtop-client = { path = "../mtop-client" }
 criterion = "0.5.1"
+mtop-client = { path = "../mtop-client" }
 
 [[bench]]
 name = "dns_name"

--- a/benches/dns_name.rs
+++ b/benches/dns_name.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use mtop_client::dns::Name;
 use std::io::Cursor;
 use std::str::FromStr;

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "fuzz"
+version = "0.0.0"
+publish = false
+edition = "2024"
+license = "GPL-3.0+"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = { version = "0.4.0", features = ["arbitrary-derive"] }
+mtop-client = { path = "../mtop-client" }
+tokio = { version = "1.14.0", features = ["full"] }
+urlencoding = "2.1.2"
+
+[[bin]]
+name = "fuzz_target_dns_name"
+path = "fuzz_targets/fuzz_target_dns_name.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_target_dns_message"
+path = "fuzz_targets/fuzz_target_dns_message.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_target_memcached_get"
+path = "fuzz_targets/fuzz_target_memcached_get.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_target_memcached_metas"
+path = "fuzz_targets/fuzz_target_memcached_metas.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/fuzz_target_dns_message.rs
+++ b/fuzz/fuzz_targets/fuzz_target_dns_message.rs
@@ -1,0 +1,16 @@
+#![no_main]
+
+use libfuzzer_sys::{Corpus, fuzz_target};
+use mtop_client::dns::Message;
+use std::io::Cursor;
+
+fuzz_target!(|data: &[u8]| -> Corpus {
+    let mut cur = Cursor::new(data);
+    if let Ok(m) = Message::read_network_bytes(&mut cur) {
+        let mut buf = Vec::new();
+        m.write_network_bytes(&mut buf).unwrap();
+        Corpus::Keep
+    } else {
+        Corpus::Reject
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_target_dns_name.rs
+++ b/fuzz/fuzz_targets/fuzz_target_dns_name.rs
@@ -1,0 +1,33 @@
+#![no_main]
+
+use libfuzzer_sys::{Corpus, fuzz_target};
+use mtop_client::MtopError;
+use mtop_client::dns::Name;
+use std::io::Cursor;
+use std::str::FromStr;
+
+fuzz_target!(|data: &[u8]| -> Corpus {
+    // Try parsing the bytes as a binary DNS name
+    let mut cur = Cursor::new(data);
+    if let Ok(n) = Name::read_network_bytes(&mut cur) {
+        let n = n.to_fqdn();
+        let _ = n.to_string();
+        let mut buf = Vec::new();
+        n.write_network_bytes(&mut buf).unwrap();
+        return Corpus::Keep;
+    }
+
+    // Try parsing the bytes as a text representation of the name
+    if let Ok(n) = str::from_utf8(data)
+        .map_err(|e| MtopError::runtime_cause("utf-8", e))
+        .and_then(Name::from_str)
+    {
+        let n = n.to_fqdn();
+        let _ = n.to_string();
+        let mut buf = Vec::new();
+        n.write_network_bytes(&mut buf).unwrap();
+        return Corpus::Keep;
+    }
+
+    Corpus::Reject
+});

--- a/fuzz/fuzz_targets/fuzz_target_memcached_get.rs
+++ b/fuzz/fuzz_targets/fuzz_target_memcached_get.rs
@@ -1,0 +1,42 @@
+#![no_main]
+
+use libfuzzer_sys::{Corpus, arbitrary, fuzz_target};
+use mtop_client::{Key, Memcached, Timeout};
+use std::io::{Cursor, Write};
+use std::sync::OnceLock;
+use std::time::Duration;
+use tokio::runtime::Runtime;
+
+const TIMEOUT: Duration = Duration::from_millis(10);
+
+static RT: OnceLock<Runtime> = OnceLock::new();
+
+#[derive(Debug, Clone, arbitrary::Arbitrary)]
+struct ValueResponse {
+    key: String,
+    flags: u64,
+    len: u64,
+    cas: u64,
+    data: Vec<u8>,
+}
+
+impl From<ValueResponse> for Vec<u8> {
+    fn from(v: ValueResponse) -> Self {
+        let mut out = Vec::with_capacity(v.data.len());
+        write!(&mut out, "VALUE {} {} {} {}\r\n", v.key, v.flags, v.len, v.cas).unwrap();
+        out.extend_from_slice(&v.data);
+        out
+    }
+}
+
+fuzz_target!(|data: ValueResponse| -> Corpus {
+    let read: Cursor<Vec<u8>> = Cursor::new(data.into());
+    let write = Vec::new();
+    let mut conn = Memcached::new(read, write);
+    let runtime = RT.get_or_init(|| Runtime::new().unwrap());
+
+    match runtime.block_on(async { conn.get(&[Key::one("foo").unwrap()]).timeout(TIMEOUT, "fuzz").await }) {
+        Ok(_v) => Corpus::Keep,
+        Err(_e) => Corpus::Reject,
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_target_memcached_metas.rs
+++ b/fuzz/fuzz_targets/fuzz_target_memcached_metas.rs
@@ -1,0 +1,51 @@
+#![no_main]
+
+use libfuzzer_sys::{Corpus, arbitrary, fuzz_target};
+use mtop_client::{Memcached, Timeout};
+use std::io::{Cursor, Write};
+use std::sync::OnceLock;
+use std::time::Duration;
+use tokio::runtime::Runtime;
+
+const TIMEOUT: Duration = Duration::from_millis(10);
+
+static RT: OnceLock<Runtime> = OnceLock::new();
+
+#[derive(Clone, Debug, arbitrary::Arbitrary)]
+struct MetasResponse {
+    lines: Vec<MetaLine>,
+}
+
+#[derive(Clone, Debug, arbitrary::Arbitrary)]
+struct MetaLine {
+    pairs: Vec<(String, String)>,
+}
+
+impl From<MetasResponse> for Vec<u8> {
+    fn from(value: MetasResponse) -> Self {
+        let mut out = Vec::new();
+
+        for line in value.lines {
+            for pair in line.pairs {
+                write!(&mut out, "{}={} ", pair.0, urlencoding::encode(&pair.1)).unwrap();
+            }
+
+            out.extend_from_slice(b"\r\n");
+        }
+
+        out.extend_from_slice(b"END\r\n");
+        out
+    }
+}
+
+fuzz_target!(|data: MetasResponse| -> Corpus {
+    let read: Cursor<Vec<u8>> = Cursor::new(data.into());
+    let write = Vec::new();
+    let mut conn = Memcached::new(read, write);
+    let runtime = RT.get_or_init(|| Runtime::new().unwrap());
+
+    match runtime.block_on(async { conn.metas().timeout(TIMEOUT, "fuzz").await }) {
+        Ok(_v) => Corpus::Keep,
+        Err(_e) => Corpus::Reject,
+    }
+});


### PR DESCRIPTION
Add fuzz testing for some DNS parsing methods and Memcached methods. This change also fixes an issue with large payloads returned by Memcached servers that could overflow a `usize` integer.