### PR TITLE
tests: Add README for fuzzing and a stats target

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -41,3 +41,10 @@ path = "fuzz_targets/fuzz_target_memcached_metas.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "fuzz_target_memcached_stats"
+path = "fuzz_targets/fuzz_target_memcached_stats.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,36 @@
+# Fuzz Testing
+
+Some parts of the `mtop` and `mtop-client` libraries are fuzz tested.
+Instructions for running fuzz tests are below.
+
+## Setup
+
+Follow the [setup instructions](https://rust-fuzz.github.io/book/cargo-fuzz/setup.html) from the Rust fuzz testing book.
+
+## Running
+
+After you have installed `cargo-fuzz` and selected the `nightly` toolchain for `mtop`, execute the 
+various `mtop` and `mtop-client` fuzz targets from the root of the `mtop` repository.
+
+```
+cargo fuzz run fuzz_target_dns_message
+```
+
+```
+cargo fuzz run fuzz_target_dns_name
+```
+
+```
+cargo fuzz run fuzz_target_memcached_get
+```
+
+```
+cargo fuzz run fuzz_target_memcached_metas
+```
+
+```
+cargo fuzz run fuzz_target_memcached_stats
+```
+
+Each of these commands will run until it encounters a panic or crash.
+You may want to stop them early if they haven't found anything after a reasonable time (30 minutes or more). 

--- a/fuzz/fuzz_targets/fuzz_target_memcached_stats.rs
+++ b/fuzz/fuzz_targets/fuzz_target_memcached_stats.rs
@@ -1,0 +1,42 @@
+#![no_main]
+
+use libfuzzer_sys::{Corpus, arbitrary, fuzz_target};
+use mtop_client::{Memcached, Timeout};
+use std::io::{Cursor, Write};
+use std::sync::OnceLock;
+use std::time::Duration;
+use tokio::runtime::Runtime;
+
+const TIMEOUT: Duration = Duration::from_millis(10);
+
+static RT: OnceLock<Runtime> = OnceLock::new();
+
+#[derive(Clone, Debug, arbitrary::Arbitrary)]
+struct StatsResponse {
+    lines: Vec<(String, u64)>,
+}
+
+impl From<StatsResponse> for Vec<u8> {
+    fn from(value: StatsResponse) -> Self {
+        let mut out = Vec::new();
+
+        for line in value.lines {
+            write!(&mut out, "STAT {} {}\r\n", line.0, line.1).unwrap();
+        }
+
+        out.extend_from_slice(b"END\r\n");
+        out
+    }
+}
+
+fuzz_target!(|data: StatsResponse| -> Corpus {
+    let read: Cursor<Vec<u8>> = Cursor::new(data.into());
+    let write = Vec::new();
+    let mut conn = Memcached::new(read, write);
+    let runtime = RT.get_or_init(|| Runtime::new().unwrap());
+
+    match runtime.block_on(async { conn.stats().timeout(TIMEOUT, "fuzz").await }) {
+        Ok(_v) => Corpus::Keep,
+        Err(_e) => Corpus::Reject,
+    }
+});


### PR DESCRIPTION
Add a README that explains how to setup and run fuzzing and add another target for the `Memcached::stats()` method.