### PR TITLE
tests: Fuzz Memcached::get with more than one value

### DIFF
--- a/fuzz/fuzz_targets/fuzz_target_memcached_get.rs
+++ b/fuzz/fuzz_targets/fuzz_target_memcached_get.rs
@@ -12,7 +12,12 @@ const TIMEOUT: Duration = Duration::from_millis(10);
 static RT: OnceLock<Runtime> = OnceLock::new();
 
 #[derive(Debug, Clone, arbitrary::Arbitrary)]
-struct ValueResponse {
+struct ValuesResponse {
+    lines: Vec<ValueLine>,
+}
+
+#[derive(Debug, Clone, arbitrary::Arbitrary)]
+struct ValueLine {
     key: String,
     flags: u64,
     len: u64,
@@ -20,22 +25,33 @@ struct ValueResponse {
     data: Vec<u8>,
 }
 
-impl From<ValueResponse> for Vec<u8> {
-    fn from(v: ValueResponse) -> Self {
-        let mut out = Vec::with_capacity(v.data.len());
-        write!(&mut out, "VALUE {} {} {} {}\r\n", v.key, v.flags, v.len, v.cas).unwrap();
-        out.extend_from_slice(&v.data);
+impl From<ValuesResponse> for Vec<u8> {
+    fn from(v: ValuesResponse) -> Self {
+        let mut out = Vec::new();
+
+        for val in v.lines {
+            write!(&mut out, "VALUE {} {} {} {}\r\n", val.key, val.flags, val.len, val.cas).unwrap();
+            out.extend_from_slice(&val.data);
+        }
+
+        out.extend_from_slice(b"END\r\n");
         out
     }
 }
 
-fuzz_target!(|data: ValueResponse| -> Corpus {
+fuzz_target!(|data: ValuesResponse| -> Corpus {
+    // Get all the keys from the generated data, ignoring invalid ones. This doesn't
+    // actually affect the data returned and the parsing logic short-circuits and returns
+    // an error after the first value it can't parse _but_ this allows us to make sure
+    // writing keys to the server works well enough.
+    let keys: Vec<Key> = data.lines.iter().flat_map(|l| Key::one(&l.key)).collect();
+
     let read: Cursor<Vec<u8>> = Cursor::new(data.into());
     let write = Vec::new();
     let mut conn = Memcached::new(read, write);
     let runtime = RT.get_or_init(|| Runtime::new().unwrap());
 
-    match runtime.block_on(async { conn.get(&[Key::one("foo").unwrap()]).timeout(TIMEOUT, "fuzz").await }) {
+    match runtime.block_on(async { conn.get(&keys).timeout(TIMEOUT, "fuzz").await }) {
         Ok(_v) => Corpus::Keep,
         Err(_e) => Corpus::Reject,
     }

--- a/mtop-client/src/core.rs
+++ b/mtop-client/src/core.rs
@@ -1015,7 +1015,7 @@ impl Memcached {
         Some(ProtocolError { kind, message })
     }
 
-    async fn send<'a>(&'a mut self, cmd: Command<'a>) -> Result<(), MtopError> {
+    async fn send(&mut self, cmd: Command<'_>) -> Result<(), MtopError> {
         let cmd_bytes: Vec<u8> = cmd.into();
         self.write.write_all(&cmd_bytes).await?;
         Ok(self.write.flush().await?)


### PR DESCRIPTION
Refactor the fuzz test for Memcached::get to include more than one value and a proper `END` after all values.

Related #215