### PR TITLE
ci: Adjust docker build to not rely on c++ compiler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM rust:slim-bookworm AS BUILD
+FROM rust:slim-bookworm AS build
 COPY . .
-RUN cargo build --release
+RUN cd mtop && cargo build --release
 
 FROM debian:bookworm-slim
-COPY --from=BUILD target/release/mtop /usr/local/bin/
-COPY --from=BUILD target/release/mc /usr/local/bin/
-COPY --from=BUILD target/release/dns /usr/local/bin/
+COPY --from=build target/release/mtop /usr/local/bin/
+COPY --from=build target/release/mc /usr/local/bin/
+COPY --from=build target/release/dns /usr/local/bin/
 CMD ["mtop", "--help"]


### PR DESCRIPTION
Change build directory so we are only building the `mtop` crate, not the fuzz crate, and don't require a c++ compiler.