### PR TITLE
ci: Mark 0.15.0 as unreleased since building releases is not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.15.0 - 2025-06-23
+## v0.15.0 - unreleased
 
 - Change retry behavior of DNS lookups (used for the `dns` binary and cache server
   service discovery) to try all configured DNS servers and then retry. #202


### PR DESCRIPTION
`cargo-dist` isn't working at the moment so it's going to take a while to automate creating releases again.