### PR TITLE
perf: inline crawler meta parsing method

### DIFF
--- a/mtop-client/src/core.rs
+++ b/mtop-client/src/core.rs
@@ -904,6 +904,7 @@ impl Memcached {
         }
     }
 
+    #[inline]
     fn parse_crawler_meta(line: &str, keys: &[&str], raw: &mut HashMap<String, String>) -> Result<Meta, MtopError> {
         assert!(raw.is_empty(), "scratch HashMap should be cleared before being used");
 


### PR DESCRIPTION
It's only called in a single place. Inlining results in about a 10% performance improvement.