### PR TITLE
client: Implement TryInto for Key type

### DIFF
--- a/benches/Cargo.lock
+++ b/benches/Cargo.lock
@@ -894,9 +894,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
@@ -904,9 +904,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -915,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -926,9 +926,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
@@ -1095,9 +1095,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.1"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/benches/memcached_core.rs
+++ b/benches/memcached_core.rs
@@ -1,5 +1,5 @@
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
-use mtop_client::{Key, Memcached};
+use mtop_client::Memcached;
 use std::io::Cursor;
 use std::sync::OnceLock;
 use tokio::runtime::Runtime;
@@ -42,20 +42,21 @@ fn memcached_read_write(c: &mut Criterion) {
             || Memcached::new(Cursor::new(GETS), Vec::new()),
             |mut conn| {
                 runtime.block_on(async {
-                    let _ = conn.get(
-                        &[
-                            Key::one("foo1").unwrap(),
-                            Key::one("foo2").unwrap(),
-                            Key::one("foo3").unwrap(),
-                            Key::one("foo4").unwrap(),
-                            Key::one("foo5").unwrap(),
-                            Key::one("foo6").unwrap(),
-                            Key::one("foo7").unwrap(),
-                            Key::one("foo8").unwrap(),
-                            Key::one("foo9").unwrap(),
-                            Key::one("foo10").unwrap(),
-                        ]
-                    ).await.unwrap();
+                    let _ = conn
+                        .get(&[
+                            "foo1".try_into().unwrap(),
+                            "foo2".try_into().unwrap(),
+                            "foo3".try_into().unwrap(),
+                            "foo4".try_into().unwrap(),
+                            "foo5".try_into().unwrap(),
+                            "foo6".try_into().unwrap(),
+                            "foo7".try_into().unwrap(),
+                            "foo8".try_into().unwrap(),
+                            "foo9".try_into().unwrap(),
+                            "foo10".try_into().unwrap(),
+                        ])
+                        .await
+                        .unwrap();
                 })
             },
             BatchSize::SmallInput,

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -627,9 +627,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
@@ -637,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -648,9 +648,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -659,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
@@ -759,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.1"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/fuzz/fuzz_targets/memcached_get.rs
+++ b/fuzz/fuzz_targets/memcached_get.rs
@@ -44,7 +44,7 @@ fuzz_target!(|data: ValuesResponse| -> Corpus {
     // actually affect the data returned and the parsing logic short-circuits and returns
     // an error after the first value it can't parse _but_ this allows us to make sure
     // writing keys to the server works well enough.
-    let keys: Vec<Key> = data.lines.iter().flat_map(|l| Key::one(&l.key)).collect();
+    let keys: Vec<Key> = data.lines.iter().flat_map(|l| (&l.key).try_into()).collect();
 
     let read: Cursor<Vec<u8>> = Cursor::new(data.into());
     let write = Vec::new();

--- a/mtop-client/src/client.rs
+++ b/mtop-client/src/client.rs
@@ -209,7 +209,7 @@ macro_rules! spawn_for_host {
 /// Run a method on a connection to a particular server based on the hash of a single key.
 macro_rules! operation_for_key {
     ($self:ident, $method:ident, $key:expr $(, $args:expr)* $(,)?) => {{
-        let key = Key::one($key)?;
+        let key = $key.try_into()?;
         let server = $self.selector.server(&key)?;
 
         run_for_host!($self.pool, &server, $method, &key, $($args,)*)
@@ -399,9 +399,9 @@ impl MemcachedClient {
     pub async fn get<I, K>(&self, keys: I) -> Result<ValuesResponse, MtopError>
     where
         I: IntoIterator<Item = K>,
-        K: Into<String>,
+        K: TryInto<Key, Error = MtopError>,
     {
-        let keys = Key::many(keys)?;
+        let keys = Key::parse_all(keys)?;
         if keys.is_empty() {
             return Ok(ValuesResponse::default());
         }
@@ -447,7 +447,7 @@ impl MemcachedClient {
     /// is established.
     pub async fn incr<K>(&self, key: K, delta: u64) -> Result<u64, MtopError>
     where
-        K: Into<String>,
+        K: TryInto<Key, Error = MtopError>,
     {
         operation_for_key!(self, incr, key, delta)
     }
@@ -461,7 +461,7 @@ impl MemcachedClient {
     /// is established.
     pub async fn decr<K>(&self, key: K, delta: u64) -> Result<u64, MtopError>
     where
-        K: Into<String>,
+        K: TryInto<Key, Error = MtopError>,
     {
         operation_for_key!(self, decr, key, delta)
     }
@@ -473,7 +473,7 @@ impl MemcachedClient {
     /// is established.
     pub async fn set<K, V>(&self, key: K, flags: u64, ttl: u32, data: V) -> Result<(), MtopError>
     where
-        K: Into<String>,
+        K: TryInto<Key, Error = MtopError>,
         V: AsRef<[u8]>,
     {
         operation_for_key!(self, set, key, flags, ttl, data)
@@ -486,7 +486,7 @@ impl MemcachedClient {
     /// is established.
     pub async fn add<K, V>(&self, key: K, flags: u64, ttl: u32, data: V) -> Result<(), MtopError>
     where
-        K: Into<String>,
+        K: TryInto<Key, Error = MtopError>,
         V: AsRef<[u8]>,
     {
         operation_for_key!(self, add, key, flags, ttl, data)
@@ -499,7 +499,7 @@ impl MemcachedClient {
     /// is established.
     pub async fn replace<K, V>(&self, key: K, flags: u64, ttl: u32, data: V) -> Result<(), MtopError>
     where
-        K: Into<String>,
+        K: TryInto<Key, Error = MtopError>,
         V: AsRef<[u8]>,
     {
         operation_for_key!(self, replace, key, flags, ttl, data)
@@ -512,7 +512,7 @@ impl MemcachedClient {
     /// is established.
     pub async fn touch<K>(&self, key: K, ttl: u32) -> Result<(), MtopError>
     where
-        K: Into<String>,
+        K: TryInto<Key, Error = MtopError>,
     {
         operation_for_key!(self, touch, key, ttl)
     }
@@ -524,7 +524,7 @@ impl MemcachedClient {
     /// is established.
     pub async fn delete<K>(&self, key: K) -> Result<(), MtopError>
     where
-        K: Into<String>,
+        K: TryInto<Key, Error = MtopError>,
     {
         operation_for_key!(self, delete, key)
     }
@@ -610,7 +610,7 @@ mod test {
 
                 Server::new(id, name)
             };
-            mapping.insert(Key::one($key).unwrap(), server.clone());
+            mapping.insert($key.try_into().unwrap(), server.clone());
             contents.insert(server, $contents.to_vec());
             )*
 

--- a/mtop-client/src/core.rs
+++ b/mtop-client/src/core.rs
@@ -1045,29 +1045,17 @@ pub struct Key(String);
 impl Key {
     const MAX_LENGTH: usize = 250;
 
-    pub fn one<T>(val: T) -> Result<Key, MtopError>
-    where
-        T: Into<String>,
-    {
-        let val = val.into();
-        if Self::is_legal_val(&val) {
-            Ok(Key(val))
-        } else {
-            Err(MtopError::runtime(format!("invalid key {}", val)))
-        }
-    }
-
-    pub fn many<I, T>(vals: I) -> Result<Vec<Key>, MtopError>
+    pub fn parse_all<I, T>(vals: I) -> Result<Vec<Self>, MtopError>
     where
         I: IntoIterator<Item = T>,
-        T: Into<String>,
+        T: TryInto<Key, Error = MtopError>,
     {
         let iter = vals.into_iter();
         let (sz, _) = iter.size_hint();
         let mut out = Vec::with_capacity(sz);
 
         for val in iter {
-            out.push(Self::one(val)?);
+            out.push(val.try_into()?);
         }
 
         Ok(out)
@@ -1079,6 +1067,18 @@ impl Key {
 
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
+    }
+
+    fn parse<T>(val: T) -> Result<Self, MtopError>
+    where
+        T: Into<String>,
+    {
+        let val = val.into();
+        if Self::is_legal_val(&val) {
+            Ok(Key(val))
+        } else {
+            Err(MtopError::runtime(format!("invalid key {}", val)))
+        }
     }
 
     fn is_legal_val(val: &str) -> bool {
@@ -1114,6 +1114,30 @@ impl Borrow<str> for Key {
     }
 }
 
+impl TryFrom<String> for Key {
+    type Error = MtopError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Key::parse(value)
+    }
+}
+
+impl TryFrom<&String> for Key {
+    type Error = MtopError;
+
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        Key::parse(value)
+    }
+}
+
+impl TryFrom<&str> for Key {
+    type Error = MtopError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Key::parse(value)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::{ErrorKind, Key, Memcached, Meta, Slab, SlabItem, SlabItems};
@@ -1129,38 +1153,63 @@ mod test {
     /////////
 
     #[test]
-    fn test_key_one_length() {
+    fn test_key_parse_length() {
         let val = "abc".repeat(Key::MAX_LENGTH);
-        let res = Key::one(val);
+        let res = Key::parse(val);
         assert!(res.is_err());
     }
 
     #[test]
-    fn test_key_one_non_ascii() {
+    fn test_key_parse_non_ascii() {
         let val = "🤦";
-        let res = Key::one(val);
+        let res = Key::parse(val);
         assert!(res.is_err());
     }
 
     #[test]
-    fn test_key_one_whitespace() {
+    fn test_key_parse_whitespace() {
         let val = "some thing";
-        let res = Key::one(val);
+        let res = Key::parse(val);
         assert!(res.is_err());
     }
 
     #[test]
-    fn test_key_one_control_char() {
+    fn test_key_parse_control_char() {
         let val = "\x7F";
-        let res = Key::one(val);
+        let res = Key::parse(val);
         assert!(res.is_err());
     }
 
     #[test]
-    fn test_key_one_success() {
+    fn test_key_parse_success() {
         let val = "a-reasonable-key";
-        let res = Key::one(val);
-        assert!(res.is_ok());
+        let key = Key::parse(val).unwrap();
+
+        assert_eq!(Key("a-reasonable-key".to_owned()), key);
+    }
+
+    #[test]
+    fn test_key_parse_all_string() {
+        let vals = vec![String::from("foo"), String::from("bar")];
+        let keys = Key::parse_all(vals).unwrap();
+
+        assert_eq!(vec![Key("foo".to_owned()), Key("bar".to_owned())], keys,);
+    }
+
+    #[test]
+    fn test_key_parse_all_string_borrowed() {
+        let vals = vec![String::from("foo"), String::from("bar")];
+        let keys = Key::parse_all(&vals).unwrap();
+
+        assert_eq!(vec![Key("foo".to_owned()), Key("bar".to_owned())], keys,);
+    }
+
+    #[test]
+    fn test_key_parse_all_str() {
+        let vals = ["foo", "bar"];
+        let keys = Key::parse_all(vals).unwrap();
+
+        assert_eq!(vec![Key("foo".to_owned()), Key("bar".to_owned())], keys,);
     }
 
     struct WriteAdapter {
@@ -1208,7 +1257,7 @@ mod test {
     async fn test_memcached_get_no_key() {
         let (_rx, mut client) = client!();
         let vals: Vec<String> = vec![];
-        let keys = Key::many(vals).unwrap();
+        let keys = Key::parse_all(vals).unwrap();
         let res = client.get(&keys).await.unwrap();
 
         assert!(res.is_empty());
@@ -1217,7 +1266,7 @@ mod test {
     #[tokio::test]
     async fn test_memcached_get_error() {
         let (_rx, mut client) = client!("SERVER_ERROR backend failure\r\n");
-        let keys = Key::many(vec!["foo", "baz"]).unwrap();
+        let keys = Key::parse_all(vec!["foo", "baz"]).unwrap();
         let res = client.get(&keys).await;
 
         assert!(res.is_err());
@@ -1228,7 +1277,7 @@ mod test {
     #[tokio::test]
     async fn test_memcached_get_miss() {
         let (_rx, mut client) = client!("END\r\n");
-        let keys = Key::many(vec!["foo", "baz"]).unwrap();
+        let keys = Key::parse_all(vec!["foo", "baz"]).unwrap();
         let res = client.get(&keys).await.unwrap();
 
         assert!(res.is_empty());
@@ -1243,7 +1292,7 @@ mod test {
             "qux\r\n",
             "END\r\n",
         );
-        let keys = Key::many(vec!["foo", "baz"]).unwrap();
+        let keys = Key::parse_all(vec!["foo", "baz"]).unwrap();
         let res = client.get(&keys).await.unwrap();
 
         let val1 = res.get("foo").unwrap();
@@ -1266,7 +1315,7 @@ mod test {
     #[tokio::test]
     async fn test_memcached_incr_bad_val() {
         let (mut rx, mut client) = client!("CLIENT_ERROR cannot increment or decrement non-numeric value\r\n");
-        let key = Key::one("test").unwrap();
+        let key = Key::parse("test").unwrap();
         let res = client.incr(&key, 2).await;
 
         assert!(res.is_err());
@@ -1281,7 +1330,7 @@ mod test {
     #[tokio::test]
     async fn test_memcached_incr_success() {
         let (mut rx, mut client) = client!("3\r\n");
-        let key = Key::one("test").unwrap();
+        let key = Key::parse("test").unwrap();
         let res = client.incr(&key, 2).await.unwrap();
 
         assert_eq!(3, res);
@@ -1297,7 +1346,7 @@ mod test {
     #[tokio::test]
     async fn test_memcached_decr_bad_val() {
         let (mut rx, mut client) = client!("CLIENT_ERROR cannot increment or decrement non-numeric value\r\n");
-        let key = Key::one("test").unwrap();
+        let key = Key::parse("test").unwrap();
         let res = client.decr(&key, 1).await;
 
         assert!(res.is_err());
@@ -1312,7 +1361,7 @@ mod test {
     #[tokio::test]
     async fn test_memcached_decr_success() {
         let (mut rx, mut client) = client!("3\r\n");
-        let key = Key::one("test").unwrap();
+        let key = Key::parse("test").unwrap();
         let res = client.decr(&key, 1).await.unwrap();
 
         assert_eq!(3, res);
@@ -1352,7 +1401,7 @@ mod test {
     macro_rules! test_store_command_success {
         ($method:ident, $verb:expr) => {
             let (mut rx, mut client) = client!("STORED\r\n");
-            let res = client.$method(&Key::one("test").unwrap(), 0, 300, "val".as_bytes()).await;
+            let res = client.$method(&Key::parse("test").unwrap(), 0, 300, "val".as_bytes()).await;
 
             assert!(res.is_ok());
             let bytes = rx.recv().await.unwrap();
@@ -1364,7 +1413,7 @@ mod test {
     macro_rules! test_store_command_error {
         ($method:ident, $verb:expr) => {
             let (mut rx, mut client) = client!("NOT_STORED\r\n");
-            let res = client.$method(&Key::one("test").unwrap(), 0, 300, "val".as_bytes()).await;
+            let res = client.$method(&Key::parse("test").unwrap(), 0, 300, "val".as_bytes()).await;
 
             assert!(res.is_err());
             let err = res.unwrap_err();
@@ -1425,7 +1474,7 @@ mod test {
     #[tokio::test]
     async fn test_memcached_touch_success() {
         let (mut rx, mut client) = client!("TOUCHED\r\n");
-        let key = Key::one("test").unwrap();
+        let key = Key::parse("test").unwrap();
         let res = client.touch(&key, 300).await;
 
         assert!(res.is_ok());
@@ -1437,7 +1486,7 @@ mod test {
     #[tokio::test]
     async fn test_memcached_touch_error() {
         let (mut rx, mut client) = client!("NOT_FOUND\r\n");
-        let key = Key::one("test").unwrap();
+        let key = Key::parse("test").unwrap();
         let res = client.touch(&key, 300).await;
 
         assert!(res.is_err());
@@ -1456,7 +1505,7 @@ mod test {
     #[tokio::test]
     async fn test_memcached_delete_success() {
         let (mut rx, mut client) = client!("DELETED\r\n");
-        let key = Key::one("test").unwrap();
+        let key = Key::parse("test").unwrap();
         let res = client.delete(&key).await;
 
         assert!(res.is_ok());
@@ -1468,7 +1517,7 @@ mod test {
     #[tokio::test]
     async fn test_memcached_delete_error() {
         let (mut rx, mut client) = client!("NOT_FOUND\r\n");
-        let key = Key::one("test").unwrap();
+        let key = Key::parse("test").unwrap();
         let res = client.delete(&key).await;
 
         assert!(res.is_err());

--- a/mtop-client/src/net/tls.rs
+++ b/mtop-client/src/net/tls.rs
@@ -65,10 +65,9 @@ async fn load_cert(path: &PathBuf) -> Result<Vec<CertificateDer<'static>>, MtopE
     let contents = fs::read(path)
         .await
         .map_err(|e| MtopError::configuration_cause(format!("unable to load cert {}", path.display()), e))?;
-    let iter = CertificateDer::pem_slice_iter(&contents);
 
     let mut out = Vec::new();
-    for res in iter {
+    for res in CertificateDer::pem_slice_iter(&contents) {
         out.push(
             res.map_err(|e| MtopError::configuration_cause(format!("unable to parse cert {}", path.display()), e))?,
         );

--- a/mtop/src/check.rs
+++ b/mtop/src/check.rs
@@ -1,4 +1,4 @@
-use mtop_client::{Discovery, Key, MemcachedClient, Timeout};
+use mtop_client::{Discovery, MemcachedClient, Timeout};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
@@ -58,7 +58,7 @@ impl Checker {
         // when doing the check.
         while !self.stop.load(Ordering::Acquire) && start.elapsed() < time {
             let _ = interval.tick().await;
-            let key = Key::one(KEY).unwrap();
+            let key = KEY.try_into().unwrap();
             let val = VALUE.to_vec();
 
             let dns_start = Instant::now();


### PR DESCRIPTION
Implement the `TryInto` conversion trait for the Key type and make the actual parsing method private.