### PR TITLE
feat: dns: add support for multiple names in a single message

### DIFF
--- a/benches/memcached_discovery.rs
+++ b/benches/memcached_discovery.rs
@@ -20,13 +20,18 @@ struct MockDnsClient {
 
 #[async_trait]
 impl DnsClient for MockDnsClient {
-    async fn resolve(
+    async fn resolve_msg(
         &self,
-        id: MessageId,
-        name: Name,
-        rtype: RecordType,
-        rclass: RecordClass,
+        message: Message,
     ) -> Result<Message, MtopError> {
+        let questions = message.questions();
+        assert_eq!(1, questions.len());
+
+        let id = message.id();
+        let name = questions[0].name().clone();
+        let rtype = questions[0].qtype();
+        let rclass = questions[0].qclass();
+        
         match self.responses.get(&(name, rtype, rclass)) {
             Some(v) => Ok(v.clone().set_id(id)),
             None => Err(MtopError::runtime("no message available")),
@@ -40,7 +45,7 @@ fn new_response_srv() -> Message {
         .set_recursion_desired()
         .set_recursion_available();
 
-    let name = Name::from_str("_memcached._tcp.example.com").unwrap();
+    let name = Name::from_str("_memcached._tcp.example.com").unwrap().to_fqdn();
 
     let mut message =
         Message::new(MessageId::random(), flags).add_question(Question::new(name.clone(), RecordType::SRV));
@@ -70,13 +75,13 @@ fn new_response_a() -> Message {
         .set_recursion_available();
 
     let mut message = Message::new(MessageId::random(), flags).add_question(Question::new(
-        Name::from_str("cache.example.com").unwrap(),
+        Name::from_str("cache.example.com").unwrap().to_fqdn(),
         RecordType::A,
     ));
 
     for i in 0..15 {
         message = message.add_answer(Record::new(
-            Name::from_str(&format!("cache{:0>2}.example.com", i)).unwrap(),
+            Name::from_str(&format!("cache{:0>2}.example.com", i)).unwrap().to_fqdn(),
             RecordType::A,
             RecordClass::INET,
             300,
@@ -95,7 +100,7 @@ fn new_response_aaaa() -> Message {
 
     // Stop trying to make ~fetch~ IPv6 happen.
     Message::new(MessageId::random(), flags).add_question(Question::new(
-        Name::from_str("cache.example.com").unwrap(),
+        Name::from_str("cache.example.com").unwrap().to_fqdn(),
         RecordType::AAAA,
     ))
 }
@@ -109,7 +114,7 @@ fn memcached_discovery_resolve_by_proto(c: &mut Criterion) {
                 let mut client = MockDnsClient::default();
                 client.responses.insert(
                     (
-                        Name::from_str("_memcached._tcp.example.com").unwrap(),
+                        Name::from_str("_memcached._tcp.example.com").unwrap().to_fqdn(),
                         RecordType::SRV,
                         RecordClass::INET,
                     ),
@@ -135,7 +140,7 @@ fn memcached_discovery_resolve_by_proto(c: &mut Criterion) {
                 let mut client = MockDnsClient::default();
                 client.responses.insert(
                     (
-                        Name::from_str("cache.example.com").unwrap(),
+                        Name::from_str("cache.example.com").unwrap().to_fqdn(),
                         RecordType::A,
                         RecordClass::INET,
                     ),
@@ -143,7 +148,7 @@ fn memcached_discovery_resolve_by_proto(c: &mut Criterion) {
                 );
                 client.responses.insert(
                     (
-                        Name::from_str("cache.example.com").unwrap(),
+                        Name::from_str("cache.example.com").unwrap().to_fqdn(),
                         RecordType::AAAA,
                         RecordClass::INET,
                     ),

--- a/mtop-client/src/discovery.rs
+++ b/mtop-client/src/discovery.rs
@@ -329,13 +329,7 @@ mod test {
 
     #[async_trait]
     impl DnsClient for MockDnsClient {
-        async fn resolve(
-            &self,
-            _id: MessageId,
-            _name: Name,
-            _rtype: RecordType,
-            _rclass: RecordClass,
-        ) -> Result<Message, MtopError> {
+        async fn resolve_msg(&self, _message: Message) -> Result<Message, MtopError> {
             let mut responses = self.responses.lock().await;
             let res = responses.pop().unwrap();
             Ok(res)

--- a/mtop-client/src/dns/client.rs
+++ b/mtop-client/src/dns/client.rs
@@ -1,7 +1,7 @@
 use crate::core::MtopError;
 use crate::dns::core::{RecordClass, RecordType};
 use crate::dns::message::{Flags, Message, MessageId, Question, ResponseCode};
-use crate::dns::name::Name;
+use crate::dns::name::{Name, NamesDisplay};
 use crate::net::tcp_connect;
 use crate::pool::{ClientFactory, ClientPool, ClientPoolConfig};
 use crate::timeout::Timeout;
@@ -63,13 +63,25 @@ impl Default for DnsClientConfig {
 /// trait exists to make testing consumers easier.
 #[async_trait]
 pub trait DnsClient {
+    /// Resolve a single domain name of the provided type, ensuring it is
+    /// fully qualified before making the query.
     async fn resolve(
         &self,
         id: MessageId,
         name: Name,
         rtype: RecordType,
         rclass: RecordClass,
-    ) -> Result<Message, MtopError>;
+    ) -> Result<Message, MtopError> {
+        let full = name.to_fqdn();
+        let flags = Flags::default().set_recursion_desired();
+        let question = Question::new(full, rtype).set_qclass(rclass);
+        let message = Message::new(id, flags).add_question(question);
+        self.resolve_msg(message).await
+    }
+
+    /// Resolve a message potentially containing multiple queries. Each name
+    /// must already be fully qualified.
+    async fn resolve_msg(&self, message: Message) -> Result<Message, MtopError>;
 }
 
 /// Implementation of a `DnsClient` that uses UDP with TCP fallback.
@@ -172,17 +184,7 @@ impl DefaultDnsClient {
 
 #[async_trait]
 impl DnsClient for DefaultDnsClient {
-    async fn resolve(
-        &self,
-        id: MessageId,
-        name: Name,
-        rtype: RecordType,
-        rclass: RecordClass,
-    ) -> Result<Message, MtopError> {
-        let full = name.to_fqdn();
-        let flags = Flags::default().set_recursion_desired();
-        let question = Question::new(full.clone(), rtype).set_qclass(rclass);
-        let message = Message::new(id, flags).add_question(question);
+    async fn resolve_msg(&self, message: Message) -> Result<Message, MtopError> {
         let start = self.starting_idx();
 
         let mut errors = Vec::new();
@@ -217,11 +219,10 @@ impl DnsClient for DefaultDnsClient {
             }
         }
 
+        let names: Vec<&Name> = message.questions().iter().map(Question::name).collect();
         Err(MtopError::runtime(format!(
-            "no nameservers returned suitable responses for name {} type {} class {}: {}",
-            full,
-            rtype,
-            rclass,
+            "no nameservers returned suitable responses for names {}: {}",
+            NamesDisplay::new(&names),
             errors.join("; ")
         )))
     }

--- a/mtop-client/src/dns/mod.rs
+++ b/mtop-client/src/dns/mod.rs
@@ -12,7 +12,7 @@ pub use crate::dns::client::{
 };
 pub use crate::dns::core::{RecordClass, RecordType};
 pub use crate::dns::message::{Flags, Message, MessageId, Operation, Question, Record, ResponseCode};
-pub use crate::dns::name::Name;
+pub use crate::dns::name::{Name, NamesDisplay};
 pub use crate::dns::rdata::{
     RecordData, RecordDataA, RecordDataAAAA, RecordDataCNAME, RecordDataNS, RecordDataOpt, RecordDataSOA,
     RecordDataSRV, RecordDataTXT, RecordDataUnknown,

--- a/mtop-client/src/dns/name.rs
+++ b/mtop-client/src/dns/name.rs
@@ -1,6 +1,7 @@
 use crate::core::MtopError;
 use byteorder::{ReadBytesExt, WriteBytesExt};
 use std::fmt;
+use std::fmt::{Formatter, Write};
 use std::io::{Read, Seek, SeekFrom};
 use std::str::FromStr;
 
@@ -312,6 +313,35 @@ impl FromStr for Name {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Self::from_bytes(s.as_bytes())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct NamesDisplay<'a, D>(&'a Vec<D>);
+
+impl<'a, D> NamesDisplay<'a, D>
+where
+    D: fmt::Display,
+{
+    pub fn new(names: &'a Vec<D>) -> Self {
+        Self(names)
+    }
+}
+
+impl<D> fmt::Display for NamesDisplay<'_, D>
+where
+    D: fmt::Display,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_char('[')?;
+        for (i, d) in self.0.iter().enumerate() {
+            if i > 0 {
+                f.write_str(", ")?;
+            }
+
+            d.fmt(f)?;
+        }
+        f.write_char(']')
     }
 }
 

--- a/mtop/src/bin/dns.rs
+++ b/mtop/src/bin/dns.rs
@@ -3,7 +3,9 @@
 use clap::{Args, Parser, Subcommand, ValueHint};
 use mtop::ping::{Bundle, DnsPinger};
 use mtop::{profile, sig};
-use mtop_client::dns::{DnsClient, Flags, Message, MessageId, Name, Question, Record, RecordClass, RecordType};
+use mtop_client::dns::{
+    DnsClient, Flags, Message, MessageId, Name, NamesDisplay, Question, Record, RecordClass, RecordType,
+};
 use std::fmt::Write;
 use std::io::Cursor;
 use std::net::SocketAddr;
@@ -127,9 +129,9 @@ struct QueryCommand {
     #[arg(long, default_value_t = DEFAULT_RECORD_CLASS)]
     rclass: RecordClass,
 
-    /// Domain name to lookup.
+    /// Domain names to lookup.
     #[arg(required = true)]
-    name: Name,
+    names: Vec<Name>,
 }
 
 /// Read a binary format DNS message from standard input and display it as dig-like text output.
@@ -147,9 +149,9 @@ struct WriteCommand {
     #[arg(long, default_value_t = DEFAULT_RECORD_CLASS)]
     rclass: RecordClass,
 
-    /// Domain name to lookup.
+    /// Domain names to lookup.
     #[arg(required = true)]
-    name: Name,
+    names: Vec<Name>,
 }
 
 #[tokio::main]
@@ -203,14 +205,19 @@ async fn run_query(cmd: &QueryCommand) -> ExitCode {
     .instrument(tracing::span!(Level::INFO, "dns::new_client"))
     .await;
 
+    let mut msg = Message::new(MessageId::random(), Flags::default().set_recursion_desired());
+    for n in &cmd.names {
+        msg = msg.add_question(Question::new(n.clone().to_fqdn(), cmd.rtype).set_qclass(cmd.rclass))
+    }
+
     let response = match client
-        .resolve(MessageId::random(), cmd.name.clone(), cmd.rtype, cmd.rclass)
+        .resolve_msg(msg)
         .instrument(tracing::span!(Level::INFO, "dns_client.resolve"))
         .await
     {
         Ok(r) => r,
         Err(e) => {
-            tracing::error!(message = "unable to perform DNS query", name = %cmd.name, err = %e);
+            tracing::error!(message = "unable to perform DNS query", names = %NamesDisplay::new(&cmd.names), err = %e);
             return ExitCode::FAILURE;
         }
     };
@@ -248,10 +255,10 @@ async fn run_read(_: &ReadCommand) -> ExitCode {
 }
 
 async fn run_write(cmd: &WriteCommand) -> ExitCode {
-    let id = MessageId::random();
-    let name = cmd.name.clone().to_fqdn();
-    let msg = Message::new(id, Flags::default().set_query().set_recursion_desired())
-        .add_question(Question::new(name, cmd.rtype).set_qclass(cmd.rclass));
+    let mut msg = Message::new(MessageId::random(), Flags::default().set_recursion_desired());
+    for n in &cmd.names {
+        msg = msg.add_question(Question::new(n.clone().to_fqdn(), cmd.rtype).set_qclass(cmd.rclass))
+    }
 
     write_binary_message(&msg).await
 }


### PR DESCRIPTION
Add support in the DNS client for multiple questions in a single message and update the CLI tool to support this too.

Useful in debugging an instance of [this issue](https://github.com/netdata/netdata/issues/18375) in https://github.com/56quarters/roger