### PR TITLE
fix: dns: revert multiple question support

### DIFF
--- a/benches/memcached_discovery.rs
+++ b/benches/memcached_discovery.rs
@@ -20,18 +20,14 @@ struct MockDnsClient {
 
 #[async_trait]
 impl DnsClient for MockDnsClient {
-    async fn resolve_msg(
+    async fn resolve(
         &self,
-        message: Message,
+        id: MessageId,
+        name: Name,
+        rtype: RecordType,
+        rclass: RecordClass,
     ) -> Result<Message, MtopError> {
-        let questions = message.questions();
-        assert_eq!(1, questions.len());
-
-        let id = message.id();
-        let name = questions[0].name().clone();
-        let rtype = questions[0].qtype();
-        let rclass = questions[0].qclass();
-        
+        let name = name.to_fqdn();
         match self.responses.get(&(name, rtype, rclass)) {
             Some(v) => Ok(v.clone().set_id(id)),
             None => Err(MtopError::runtime("no message available")),

--- a/mtop-client/src/discovery.rs
+++ b/mtop-client/src/discovery.rs
@@ -329,7 +329,13 @@ mod test {
 
     #[async_trait]
     impl DnsClient for MockDnsClient {
-        async fn resolve_msg(&self, _message: Message) -> Result<Message, MtopError> {
+        async fn resolve(
+            &self,
+            _id: MessageId,
+            _name: Name,
+            _rtype: RecordType,
+            _rclass: RecordClass,
+        ) -> Result<Message, MtopError> {
             let mut responses = self.responses.lock().await;
             let res = responses.pop().unwrap();
             Ok(res)

--- a/mtop-client/src/dns/client.rs
+++ b/mtop-client/src/dns/client.rs
@@ -1,7 +1,7 @@
 use crate::core::MtopError;
 use crate::dns::core::{RecordClass, RecordType};
 use crate::dns::message::{Flags, Message, MessageId, Question, ResponseCode};
-use crate::dns::name::{Name, NamesDisplay};
+use crate::dns::name::Name;
 use crate::net::tcp_connect;
 use crate::pool::{ClientFactory, ClientPool, ClientPoolConfig};
 use crate::timeout::Timeout;
@@ -71,17 +71,7 @@ pub trait DnsClient {
         name: Name,
         rtype: RecordType,
         rclass: RecordClass,
-    ) -> Result<Message, MtopError> {
-        let full = name.to_fqdn();
-        let flags = Flags::default().set_recursion_desired();
-        let question = Question::new(full, rtype).set_qclass(rclass);
-        let message = Message::new(id, flags).add_question(question);
-        self.resolve_msg(message).await
-    }
-
-    /// Resolve a message potentially containing multiple queries. Each name
-    /// must already be fully qualified.
-    async fn resolve_msg(&self, message: Message) -> Result<Message, MtopError>;
+    ) -> Result<Message, MtopError>;
 }
 
 /// Implementation of a `DnsClient` that uses UDP with TCP fallback.
@@ -184,7 +174,18 @@ impl DefaultDnsClient {
 
 #[async_trait]
 impl DnsClient for DefaultDnsClient {
-    async fn resolve_msg(&self, message: Message) -> Result<Message, MtopError> {
+    async fn resolve(
+        &self,
+        id: MessageId,
+        name: Name,
+        rtype: RecordType,
+        rclass: RecordClass,
+    ) -> Result<Message, MtopError> {
+        let full = name.to_fqdn();
+        let flags = Flags::default().set_recursion_desired();
+        let question = Question::new(full.clone(), rtype).set_qclass(rclass);
+        let message = Message::new(id, flags).add_question(question);
+
         let start = self.starting_idx();
 
         let mut errors = Vec::new();
@@ -219,11 +220,10 @@ impl DnsClient for DefaultDnsClient {
             }
         }
 
-        let names: Vec<&Name> = message.questions().iter().map(Question::name).collect();
         Err(MtopError::runtime(format!(
             "no nameservers returned suitable responses for names {}: {}",
-            NamesDisplay::new(&names),
-            errors.join("; ")
+            full,
+            errors.join("; "),
         )))
     }
 }

--- a/mtop-client/src/dns/mod.rs
+++ b/mtop-client/src/dns/mod.rs
@@ -12,7 +12,7 @@ pub use crate::dns::client::{
 };
 pub use crate::dns::core::{RecordClass, RecordType};
 pub use crate::dns::message::{Flags, Message, MessageId, Operation, Question, Record, ResponseCode};
-pub use crate::dns::name::{Name, NamesDisplay};
+pub use crate::dns::name::Name;
 pub use crate::dns::rdata::{
     RecordData, RecordDataA, RecordDataAAAA, RecordDataCNAME, RecordDataNS, RecordDataOpt, RecordDataSOA,
     RecordDataSRV, RecordDataTXT, RecordDataUnknown,

--- a/mtop-client/src/dns/name.rs
+++ b/mtop-client/src/dns/name.rs
@@ -1,7 +1,6 @@
 use crate::core::MtopError;
 use byteorder::{ReadBytesExt, WriteBytesExt};
 use std::fmt;
-use std::fmt::{Formatter, Write};
 use std::io::{Read, Seek, SeekFrom};
 use std::str::FromStr;
 
@@ -313,35 +312,6 @@ impl FromStr for Name {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Self::from_bytes(s.as_bytes())
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct NamesDisplay<'a, D>(&'a Vec<D>);
-
-impl<'a, D> NamesDisplay<'a, D>
-where
-    D: fmt::Display,
-{
-    pub fn new(names: &'a Vec<D>) -> Self {
-        Self(names)
-    }
-}
-
-impl<D> fmt::Display for NamesDisplay<'_, D>
-where
-    D: fmt::Display,
-{
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.write_char('[')?;
-        for (i, d) in self.0.iter().enumerate() {
-            if i > 0 {
-                f.write_str(", ")?;
-            }
-
-            d.fmt(f)?;
-        }
-        f.write_char(']')
     }
 }
 

--- a/mtop/src/bin/dns.rs
+++ b/mtop/src/bin/dns.rs
@@ -3,9 +3,7 @@
 use clap::{Args, Parser, Subcommand, ValueHint};
 use mtop::ping::{Bundle, DnsPinger};
 use mtop::{profile, sig};
-use mtop_client::dns::{
-    DnsClient, Flags, Message, MessageId, Name, NamesDisplay, Question, Record, RecordClass, RecordType,
-};
+use mtop_client::dns::{DnsClient, Flags, Message, MessageId, Name, Question, Record, RecordClass, RecordType};
 use std::fmt::Write;
 use std::io::Cursor;
 use std::net::SocketAddr;
@@ -129,9 +127,9 @@ struct QueryCommand {
     #[arg(long, default_value_t = DEFAULT_RECORD_CLASS)]
     rclass: RecordClass,
 
-    /// Domain names to lookup.
+    /// Domain name to lookup.
     #[arg(required = true)]
-    names: Vec<Name>,
+    name: Name,
 }
 
 /// Read a binary format DNS message from standard input and display it as dig-like text output.
@@ -149,9 +147,9 @@ struct WriteCommand {
     #[arg(long, default_value_t = DEFAULT_RECORD_CLASS)]
     rclass: RecordClass,
 
-    /// Domain names to lookup.
+    /// Domain name to lookup.
     #[arg(required = true)]
-    names: Vec<Name>,
+    name: Name,
 }
 
 #[tokio::main]
@@ -205,19 +203,14 @@ async fn run_query(cmd: &QueryCommand) -> ExitCode {
     .instrument(tracing::span!(Level::INFO, "dns::new_client"))
     .await;
 
-    let mut msg = Message::new(MessageId::random(), Flags::default().set_recursion_desired());
-    for n in &cmd.names {
-        msg = msg.add_question(Question::new(n.clone().to_fqdn(), cmd.rtype).set_qclass(cmd.rclass))
-    }
-
     let response = match client
-        .resolve_msg(msg)
+        .resolve(MessageId::random(), cmd.name.clone(), cmd.rtype, cmd.rclass)
         .instrument(tracing::span!(Level::INFO, "dns_client.resolve"))
         .await
     {
         Ok(r) => r,
         Err(e) => {
-            tracing::error!(message = "unable to perform DNS query", names = %NamesDisplay::new(&cmd.names), err = %e);
+            tracing::error!(message = "unable to perform DNS query", names = %cmd.name, err = %e);
             return ExitCode::FAILURE;
         }
     };
@@ -255,10 +248,8 @@ async fn run_read(_: &ReadCommand) -> ExitCode {
 }
 
 async fn run_write(cmd: &WriteCommand) -> ExitCode {
-    let mut msg = Message::new(MessageId::random(), Flags::default().set_recursion_desired());
-    for n in &cmd.names {
-        msg = msg.add_question(Question::new(n.clone().to_fqdn(), cmd.rtype).set_qclass(cmd.rclass))
-    }
+    let msg = Message::new(MessageId::random(), Flags::default().set_recursion_desired())
+        .add_question(Question::new(cmd.name.clone().to_fqdn(), cmd.rtype).set_qclass(cmd.rclass));
 
     write_binary_message(&msg).await
 }


### PR DESCRIPTION
Almost no DNS servers support multiple questions in a single message because it's ambiguous.

Reverts #264