### PR TITLE
dns: default to not pooling client connections or sockets

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_FUZZ_VERSION: 0.12.0
+  CARGO_FUZZ_VERSION: 0.13.2
   FUZZ_TIME: 60
 
 jobs:
@@ -49,6 +49,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: Rustup
       run: rustup update nightly && rustup default nightly
+    - name: Versions
+      run: cargo --version && rustc --version
     - uses: actions/cache@v4
       with:
         path: ${{ runner.tool_cache }}/cargo-fuzz
@@ -57,8 +59,6 @@ jobs:
       run: echo "${{ runner.tool_cache }}/cargo-fuzz/bin" >> $GITHUB_PATH
     - name: Cargo fuzz
       run: cargo install --root "${{ runner.tool_cache }}/cargo-fuzz" --version ${{ env.CARGO_FUZZ_VERSION }} cargo-fuzz --locked
-    - name: Versions
-      run: cargo --version && rustc --version && cargo fuzz --version
     - name: Fuzz build
       run: cd fuzz && cargo fuzz build ${{ matrix.fuzz_target }}
     - name: Fuzz run

--- a/mtop-client/src/dns/client.rs
+++ b/mtop-client/src/dns/client.rs
@@ -39,8 +39,8 @@ pub struct DnsClientConfig {
     /// the nameservers are tried in-order for each resolution.
     pub rotate: bool,
 
-    /// Max number of open sockets or connections to each nameserver. Default is to keep one
-    /// open socket or connection per nameserver. Set to 0 to disable this behavior.
+    /// Max number of open sockets or connections to each nameserver. Default is not to keep
+    /// any open socket or connections open.
     pub pool_max_idle: u64,
 }
 
@@ -52,7 +52,7 @@ impl Default for DnsClientConfig {
             timeout: Duration::from_secs(5),
             attempts: 2,
             rotate: false,
-            pool_max_idle: 1,
+            pool_max_idle: 0,
         }
     }
 }
@@ -426,7 +426,10 @@ mod test {
     use crate::dns::message::{Flags, Message, MessageId, Question, Record, ResponseCode};
     use crate::dns::name::Name;
     use crate::dns::rdata::{RecordData, RecordDataA};
-    use crate::dns::test::{TestTcpClientFactory, TestTcpSocket, TestUdpClientFactory, TestUdpSocket};
+    use crate::dns::test::{
+        TestPooledTcpClientFactory, TestPooledUdpClientFactory, TestTcpSocket, TestUdpSocket,
+        TestUnpooledTcpClientFactory, TestUnpooledUdpClientFactory,
+    };
     use std::collections::HashMap;
     use std::io::Cursor;
     use std::net::{Ipv4Addr, SocketAddr};
@@ -589,8 +592,8 @@ mod test {
 
         let mut udp_mapping: HashMap<SocketAddr, Vec<Message>> = HashMap::new();
         udp_mapping.entry(server).or_default().push(udp_response);
-        let udp_factory = TestUdpClientFactory::new(udp_mapping);
-        let tcp_factory = TestTcpClientFactory::new(HashMap::new());
+        let udp_factory = TestUnpooledUdpClientFactory::new(udp_mapping);
+        let tcp_factory = TestUnpooledTcpClientFactory::new(HashMap::new());
 
         let cfg = DnsClientConfig::default();
         let client = DefaultDnsClient::new(cfg, udp_factory, tcp_factory);
@@ -609,8 +612,8 @@ mod test {
         let udp_response = new_response(id);
         let mut udp_mapping: HashMap<SocketAddr, Vec<Message>> = HashMap::new();
         udp_mapping.entry(server).or_default().push(udp_response.clone());
-        let udp_factory = TestUdpClientFactory::new(udp_mapping);
-        let tcp_factory = TestTcpClientFactory::new(HashMap::new());
+        let udp_factory = TestUnpooledUdpClientFactory::new(udp_mapping);
+        let tcp_factory = TestUnpooledTcpClientFactory::new(HashMap::new());
 
         let cfg = DnsClientConfig::default();
         let client = DefaultDnsClient::new(cfg, udp_factory, tcp_factory);
@@ -635,8 +638,8 @@ mod test {
         entry.push(udp_response2.clone());
         entry.push(udp_response1);
 
-        let udp_factory = TestUdpClientFactory::new(udp_mapping);
-        let tcp_factory = TestTcpClientFactory::new(HashMap::new());
+        let udp_factory = TestUnpooledUdpClientFactory::new(udp_mapping);
+        let tcp_factory = TestUnpooledTcpClientFactory::new(HashMap::new());
 
         let cfg = DnsClientConfig::default();
         let client = DefaultDnsClient::new(cfg, udp_factory, tcp_factory);
@@ -664,8 +667,8 @@ mod test {
         entry.push(udp_response2.clone());
         entry.push(udp_response1);
 
-        let udp_factory = TestUdpClientFactory::new(udp_mapping);
-        let tcp_factory = TestTcpClientFactory::new(HashMap::new());
+        let udp_factory = TestUnpooledUdpClientFactory::new(udp_mapping);
+        let tcp_factory = TestUnpooledTcpClientFactory::new(HashMap::new());
 
         let cfg = DnsClientConfig::default();
         let client = DefaultDnsClient::new(cfg, udp_factory, tcp_factory);
@@ -690,8 +693,8 @@ mod test {
         udp_mapping.entry(server1).or_default().push(udp_response1);
         udp_mapping.entry(server2).or_default().push(udp_response2.clone());
 
-        let udp_factory = TestUdpClientFactory::new(udp_mapping);
-        let tcp_factory = TestTcpClientFactory::new(HashMap::new());
+        let udp_factory = TestUnpooledUdpClientFactory::new(udp_mapping);
+        let tcp_factory = TestUnpooledTcpClientFactory::new(HashMap::new());
 
         let cfg = DnsClientConfig {
             nameservers: vec![server1, server2],
@@ -720,13 +723,53 @@ mod test {
         let mut tcp_mapping: HashMap<SocketAddr, Vec<Message>> = HashMap::new();
         tcp_mapping.entry(server).or_default().push(tcp_response.clone());
 
-        let udp_factory = TestUdpClientFactory::new(udp_mapping);
-        let tcp_factory = TestTcpClientFactory::new(tcp_mapping);
+        let udp_factory = TestUnpooledUdpClientFactory::new(udp_mapping);
+        let tcp_factory = TestUnpooledTcpClientFactory::new(tcp_mapping);
 
         let cfg = DnsClientConfig::default();
         let client = DefaultDnsClient::new(cfg, udp_factory, tcp_factory);
         let result = client.resolve(id, name, RecordType::A, RecordClass::INET).await.unwrap();
 
         assert_eq!(tcp_response, result);
+    }
+
+    #[tokio::test]
+    async fn test_default_dns_client_resolve_tcp_reuse() {
+        let id = MessageId::from(123);
+        let name = Name::from_str("example.com.").unwrap();
+        let server = "127.0.0.1:53".parse().unwrap();
+
+        let udp_response = new_empty_response(id);
+        let flags = udp_response.flags().set_truncated();
+        let udp_response = udp_response.set_flags(flags);
+        let tcp_response = new_response(id);
+
+        let mut udp_mapping: HashMap<SocketAddr, Vec<Message>> = HashMap::new();
+        let udp_entry = udp_mapping.entry(server).or_default();
+        udp_entry.push(udp_response.clone());
+        udp_entry.push(udp_response.clone());
+
+        let mut tcp_mapping: HashMap<SocketAddr, Vec<Message>> = HashMap::new();
+        let tcp_entry = tcp_mapping.entry(server).or_default();
+        tcp_entry.push(tcp_response.clone());
+        tcp_entry.push(tcp_response.clone());
+
+        let udp_factory = TestPooledUdpClientFactory::new(udp_mapping);
+        let tcp_factory = TestPooledTcpClientFactory::new(tcp_mapping);
+
+        let cfg = DnsClientConfig {
+            pool_max_idle: 1,
+            ..Default::default()
+        };
+        let client = DefaultDnsClient::new(cfg, udp_factory, tcp_factory);
+
+        let result1 = client
+            .resolve(id, name.clone(), RecordType::A, RecordClass::INET)
+            .await
+            .unwrap();
+        assert_eq!(tcp_response, result1);
+
+        let result2 = client.resolve(id, name, RecordType::A, RecordClass::INET).await.unwrap();
+        assert_eq!(tcp_response, result2);
     }
 }

--- a/mtop-client/src/dns/test.rs
+++ b/mtop-client/src/dns/test.rs
@@ -10,6 +10,7 @@ use std::net::SocketAddr;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::sync::Mutex;
 
 /// Test implementation of `AsyncRead` and `AsyncWrite` that reads and writes
 /// UDP format DNS bytes based on provided `Message` objects. The expected size
@@ -116,28 +117,60 @@ impl AsyncWrite for TestTcpSocket {
 }
 
 /// Test implementation of `ClientFactory` for creating `UdpConnection` instances that
-/// read provided `Message` objects.
+/// read multiple provided `Message` objects.
 #[derive(Debug)]
-pub(crate) struct TestUdpClientFactory {
-    messages: HashMap<SocketAddr, Vec<Message>>,
+pub(crate) struct TestPooledUdpClientFactory {
+    messages: Mutex<HashMap<SocketAddr, Vec<Message>>>,
 }
 
-impl TestUdpClientFactory {
+impl TestPooledUdpClientFactory {
     #[allow(dead_code)]
     pub(crate) fn new(messages: HashMap<SocketAddr, Vec<Message>>) -> Self {
-        Self { messages }
+        Self {
+            messages: Mutex::new(messages),
+        }
     }
 }
 
 #[async_trait]
-impl ClientFactory<SocketAddr, UdpConnection> for TestUdpClientFactory {
+impl ClientFactory<SocketAddr, UdpConnection> for TestPooledUdpClientFactory {
     async fn make(&self, key: &SocketAddr) -> Result<UdpConnection, MtopError> {
-        let messages = self
-            .messages
-            .get(key)
-            .ok_or_else(|| MtopError::runtime(format!("no messages configured for {}", key)))?;
+        let mut messages = self.messages.lock().await;
+        let sock_messages = messages.remove(key).unwrap();
 
-        let sock = TestUdpSocket::new(messages.clone());
+        let sock = TestUdpSocket::new(sock_messages);
+        let (read, write) = tokio::io::split(sock);
+        Ok(UdpConnection::new(read, write))
+    }
+}
+
+/// Test implementation of `ClientFactory` for creating `UdpConnection` instances that
+/// read a single provided `Message` object at time.
+#[derive(Debug)]
+pub(crate) struct TestUnpooledUdpClientFactory {
+    messages: Mutex<HashMap<SocketAddr, Vec<Message>>>,
+}
+
+impl TestUnpooledUdpClientFactory {
+    #[allow(dead_code)]
+    pub(crate) fn new(messages: HashMap<SocketAddr, Vec<Message>>) -> Self {
+        Self {
+            messages: Mutex::new(messages),
+        }
+    }
+}
+
+#[async_trait]
+impl ClientFactory<SocketAddr, UdpConnection> for TestUnpooledUdpClientFactory {
+    async fn make(&self, key: &SocketAddr) -> Result<UdpConnection, MtopError> {
+        let mut messages = self.messages.lock().await;
+        let sock_message = messages
+            .get_mut(key)
+            .ok_or_else(|| MtopError::runtime(format!("no messages configured for {}", key)))?
+            .pop()
+            .unwrap();
+
+        let sock = TestUdpSocket::new(vec![sock_message]);
         let (read, write) = tokio::io::split(sock);
         Ok(UdpConnection::new(read, write))
     }
@@ -146,26 +179,58 @@ impl ClientFactory<SocketAddr, UdpConnection> for TestUdpClientFactory {
 /// Test implementation of `ClientFactory` for creating `TcpConnection` instances that
 /// read provided `Message` objects.
 #[derive(Debug)]
-pub(crate) struct TestTcpClientFactory {
-    messages: HashMap<SocketAddr, Vec<Message>>,
+pub(crate) struct TestPooledTcpClientFactory {
+    messages: Mutex<HashMap<SocketAddr, Vec<Message>>>,
 }
 
-impl TestTcpClientFactory {
+impl TestPooledTcpClientFactory {
     #[allow(dead_code)]
     pub(crate) fn new(messages: HashMap<SocketAddr, Vec<Message>>) -> Self {
-        Self { messages }
+        Self {
+            messages: Mutex::new(messages),
+        }
     }
 }
 
 #[async_trait]
-impl ClientFactory<SocketAddr, TcpConnection> for TestTcpClientFactory {
+impl ClientFactory<SocketAddr, TcpConnection> for TestPooledTcpClientFactory {
     async fn make(&self, key: &SocketAddr) -> Result<TcpConnection, MtopError> {
-        let messages = self
-            .messages
-            .get(key)
-            .ok_or_else(|| MtopError::runtime(format!("no messages configured for {}", key)))?;
+        let mut messages = self.messages.lock().await;
+        let sock_messages = messages.remove(key).unwrap();
 
-        let sock = TestTcpSocket::new(messages.clone());
+        let sock = TestTcpSocket::new(sock_messages);
+        let (read, write) = tokio::io::split(sock);
+        Ok(TcpConnection::new(read, write))
+    }
+}
+
+/// Test implementation of `ClientFactory` for creating `TcpConnection` instances that
+/// read a single provided `Message` object at a time.
+#[derive(Debug)]
+pub(crate) struct TestUnpooledTcpClientFactory {
+    messages: Mutex<HashMap<SocketAddr, Vec<Message>>>,
+}
+
+impl TestUnpooledTcpClientFactory {
+    #[allow(dead_code)]
+    pub(crate) fn new(messages: HashMap<SocketAddr, Vec<Message>>) -> Self {
+        Self {
+            messages: Mutex::new(messages),
+        }
+    }
+}
+
+#[async_trait]
+impl ClientFactory<SocketAddr, TcpConnection> for TestUnpooledTcpClientFactory {
+    async fn make(&self, key: &SocketAddr) -> Result<TcpConnection, MtopError> {
+        let mut messages = self.messages.lock().await;
+        let sock_message = messages
+            .get_mut(key)
+            .ok_or_else(|| MtopError::runtime(format!("no messages configured for {}", key)))?
+            .pop()
+            .unwrap();
+
+        let sock = TestTcpSocket::new(vec![sock_message]);
         let (read, write) = tokio::io::split(sock);
         Ok(TcpConnection::new(read, write))
     }


### PR DESCRIPTION
Don't pool UDP sockets or TCP connections to DNS servers by default since some resolvers aggressively close idle connections (systemd-resolved).