### PR TITLE
cli: switch time options to duration string options

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,6 +45,7 @@ jobs:
         - fuzz_target: fuzz_target_memcached_get
         - fuzz_target: fuzz_target_memcached_metas
         - fuzz_target: fuzz_target_memcached_stats
+        - fuzz_target: fuzz_target_mtop_duration
     steps:
     - uses: actions/checkout@v4
     - name: Rustup

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -18,6 +18,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +95,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,12 +138,124 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+ "terminal_size",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "compact_str"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -131,10 +270,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "foldhash"
@@ -147,6 +302,7 @@ name = "fuzz"
 version = "0.0.0"
 dependencies = [
  "libfuzzer-sys",
+ "mtop",
  "mtop-client",
  "tokio",
  "urlencoding",
@@ -201,6 +357,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -223,6 +381,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,6 +396,37 @@ dependencies = [
  "hashbrown 0.17.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -251,6 +446,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,9 +459,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -271,6 +472,24 @@ dependencies = [
  "arbitrary",
  "cc",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
@@ -287,6 +506,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "memchr"
@@ -310,8 +538,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "mtop"
+version = "0.16.2"
+dependencies = [
+ "clap",
+ "crossterm",
+ "mtop-client",
+ "rand",
+ "rand_distr",
+ "ratatui",
+ "rustls-pki-types",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -328,6 +573,25 @@ dependencies = [
  "tracing",
  "urlencoding",
  "webpki-roots",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -369,6 +633,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,18 +656,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -432,6 +702,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_distr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,6 +760,32 @@ name = "rustc-demangle"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "rustls"
@@ -493,6 +820,18 @@ dependencies = [
  "rustls-pki-types",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "scopeguard"
@@ -549,10 +888,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -580,6 +949,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,6 +997,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -667,10 +1089,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
@@ -765,6 +1228,28 @@ checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,6 +12,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = { version = "0.4.0", features = ["arbitrary-derive"] }
+mtop = { path = "../mtop" }
 mtop-client = { path = "../mtop-client" }
 tokio = { version = "1.14.0", features = ["full"] }
 urlencoding = "2.1.2"
@@ -47,6 +48,13 @@ bench = false
 [[bin]]
 name = "fuzz_target_memcached_stats"
 path = "fuzz_targets/memcached_stats.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_target_mtop_duration"
+path = "fuzz_targets/mtop_duration.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -32,5 +32,9 @@ cargo fuzz run fuzz_target_memcached_metas
 cargo fuzz run fuzz_target_memcached_stats
 ```
 
+```
+cargo fuzz run fuzz_target_mtop_duration
+```
+
 Each of these commands will run until it encounters a panic or crash.
 You may want to stop them early if they haven't found anything after a reasonable time (30 minutes or more). 

--- a/fuzz/fuzz_targets/mtop_duration.rs
+++ b/fuzz/fuzz_targets/mtop_duration.rs
@@ -1,0 +1,11 @@
+#![no_main]
+
+use libfuzzer_sys::{Corpus, fuzz_target};
+use mtop::duration::DurationString;
+
+fuzz_target!(|data: String| -> Corpus {
+    match data.parse::<DurationString>() {
+        Ok(_v) => Corpus::Keep,
+        Err(_e) => Corpus::Reject,
+    }
+});

--- a/mtop-client/src/client.rs
+++ b/mtop-client/src/client.rs
@@ -371,7 +371,7 @@ impl MemcachedClient {
     /// A future is spawned for each server with results and any errors indexed by server. A
     /// pooled connection to each server is used if available, otherwise new connections are
     /// established.
-    pub async fn flush_all(&self, wait: Option<Duration>) -> Result<ServersResponse<()>, MtopError> {
+    pub async fn flush_all(&self, wait: Duration) -> Result<ServersResponse<()>, MtopError> {
         // Note that we aren't using operation_for_all! here because we want to pass a
         // different delay argument to each server. This allows callers to flush the cache
         // in one server after another, with a delay between each for safety.
@@ -381,7 +381,7 @@ impl MemcachedClient {
             .into_iter()
             .enumerate()
             .map(|(i, server)| {
-                let delay = wait.map(|d| d * u32::try_from(i).unwrap());
+                let delay = wait * u32::try_from(i).unwrap();
                 (server.id().clone(), spawn_for_host!(self, &server, flush_all, delay))
             })
             .collect::<Vec<_>>();
@@ -785,7 +785,7 @@ mod test {
             "cache02.example.com:11211" => "unused2" => "OK\r\n".as_bytes(),
         );
 
-        let res = client.flush_all(None).await;
+        let res = client.flush_all(Duration::ZERO).await;
         let response = res.unwrap();
 
         assert!(response.values.contains_key(&ServerID::from(("cache01.example.com", 11211))));
@@ -799,7 +799,7 @@ mod test {
             "cache02.example.com:11211" => "unused2" => "ERROR\r\n".as_bytes(),
         );
 
-        let res = client.flush_all(None).await;
+        let res = client.flush_all(Duration::ZERO).await;
         let response = res.unwrap();
 
         assert!(response.values.contains_key(&ServerID::from(("cache01.example.com", 11211))));
@@ -813,7 +813,7 @@ mod test {
             "cache02.example.com:11211" => "unused2" => "OK\r\n".as_bytes(),
         );
 
-        let res = client.flush_all(Some(Duration::from_secs(5))).await;
+        let res = client.flush_all(Duration::from_secs(5)).await;
         let response = res.unwrap();
 
         assert!(response.values.contains_key(&ServerID::from(("cache01.example.com", 11211))));
@@ -827,7 +827,7 @@ mod test {
             "cache02.example.com:11211" => "unused2" => "ERROR\r\n".as_bytes(),
         );
 
-        let res = client.flush_all(Some(Duration::from_secs(5))).await;
+        let res = client.flush_all(Duration::from_secs(5)).await;
         let response = res.unwrap();
 
         assert!(response.values.contains_key(&ServerID::from(("cache01.example.com", 11211))));

--- a/mtop-client/src/core.rs
+++ b/mtop-client/src/core.rs
@@ -632,8 +632,7 @@ enum Command<'a> {
     CrawlerMetadump,
     Decr(&'a Key, u64),
     Delete(&'a Key),
-    FlushAll,
-    FlushAllWait(u64),
+    FlushAll(u64),
     Gets(&'a [Key]),
     Incr(&'a Key, u64),
     MetaNoop,
@@ -652,8 +651,7 @@ impl<'a> From<Command<'a>> for Vec<u8> {
             Command::CrawlerMetadump => "lru_crawler metadump hash\r\n".to_owned().into_bytes(),
             Command::Decr(key, delta) => format!("decr {} {}\r\n", key, delta).into_bytes(),
             Command::Delete(key) => format!("delete {}\r\n", key).into_bytes(),
-            Command::FlushAll => "flush_all\r\n".to_owned().into_bytes(),
-            Command::FlushAllWait(wait) => format!("flush_all {}\r\n", wait).into_bytes(),
+            Command::FlushAll(wait) => format!("flush_all {}\r\n", wait).into_bytes(),
             Command::Gets(keys) => format!("gets {}\r\n", keys.join(" ")).into_bytes(),
             Command::Incr(key, delta) => format!("incr {} {}\r\n", key, delta).into_bytes(),
             Command::MetaNoop => "mn\r\n".to_owned().into_bytes(),
@@ -768,14 +766,8 @@ impl Memcached {
 
     /// Flush all entries in the cache, optionally after a delay. When a delay is used, the
     /// server will flush entries after a delay but the call will still return immediately.
-    pub async fn flush_all(&mut self, wait: Option<Duration>) -> Result<(), MtopError> {
-        let cmd = if let Some(d) = wait {
-            Command::FlushAllWait(d.as_secs())
-        } else {
-            Command::FlushAll
-        };
-
-        self.send(cmd).await?;
+    pub async fn flush_all(&mut self, wait: Duration) -> Result<(), MtopError> {
+        self.send(Command::FlushAll(wait.as_secs())).await?;
         self.read_simple_response("OK").await
     }
 
@@ -1536,8 +1528,7 @@ mod test {
     #[tokio::test]
     async fn test_memcached_flush_all_with_wait_success() {
         let (mut rx, mut client) = client!("OK\r\n");
-        let wait = Some(Duration::from_secs(25));
-        let res = client.flush_all(wait).await;
+        let res = client.flush_all(Duration::from_secs(25)).await;
 
         assert!(res.is_ok());
         let bytes = rx.recv().await.unwrap();
@@ -1548,8 +1539,7 @@ mod test {
     #[tokio::test]
     async fn test_memcached_flush_all_with_wait_error() {
         let (mut rx, mut client) = client!("ERROR\r\n");
-        let wait = Some(Duration::from_secs(25));
-        let res = client.flush_all(wait).await;
+        let res = client.flush_all(Duration::from_secs(25)).await;
 
         assert!(res.is_err());
         let err = res.unwrap_err();
@@ -1563,18 +1553,18 @@ mod test {
     #[tokio::test]
     async fn test_memcached_flush_all_no_wait_success() {
         let (mut rx, mut client) = client!("OK\r\n");
-        let res = client.flush_all(None).await;
+        let res = client.flush_all(Duration::ZERO).await;
 
         assert!(res.is_ok());
         let bytes = rx.recv().await.unwrap();
         let command = String::from_utf8(bytes).unwrap();
-        assert_eq!("flush_all\r\n", command);
+        assert_eq!("flush_all 0\r\n", command);
     }
 
     #[tokio::test]
     async fn test_memcached_flush_all_no_wait_error() {
         let (mut rx, mut client) = client!("ERROR\r\n");
-        let res = client.flush_all(None).await;
+        let res = client.flush_all(Duration::ZERO).await;
 
         assert!(res.is_err());
         let err = res.unwrap_err();
@@ -1582,7 +1572,7 @@ mod test {
 
         let bytes = rx.recv().await.unwrap();
         let command = String::from_utf8(bytes).unwrap();
-        assert_eq!("flush_all\r\n", command);
+        assert_eq!("flush_all 0\r\n", command);
     }
 
     ///////////

--- a/mtop/src/bench.rs
+++ b/mtop/src/bench.rs
@@ -18,7 +18,7 @@ const GET_BATCH_SIZE: usize = 100;
 pub struct Percent(f64);
 
 impl Percent {
-    pub fn unchecked(v: f64) -> Self {
+    pub fn must(v: f64) -> Self {
         assert!(v >= 0.0, "percent must be >= 0.0");
         assert!(v <= 1.0, "percent must be <= 1.0");
         Self(v)

--- a/mtop/src/bin/mc.rs
+++ b/mtop/src/bin/mc.rs
@@ -1,6 +1,7 @@
 use clap::{Args, Parser, Subcommand, ValueHint};
 use mtop::bench::{Bencher, Percent, Summary};
 use mtop::check::{Bundle, Checker};
+use mtop::duration::DurationString;
 use mtop::profile;
 use mtop_client::{Discovery, MemcachedClient, Meta, MtopError, Timeout, TlsConfig, Value};
 use rustls_pki_types::{InvalidDnsNameError, ServerName};
@@ -37,6 +38,10 @@ struct McConfig {
     /// Timeout for Memcached network operations, in seconds.
     #[arg(long, env = "MC_TIMEOUT_SECS", default_value_t = NonZeroU64::new(30).unwrap())]
     timeout_secs: NonZeroU64,
+
+    /// Timeout for Memcached network operations, in duration string format (value followed by units: 'h', 'm', 's', 'ms', 'us', 'ns').
+    #[arg(long, env = "MC_TIMEOUT", default_value_t = DurationString::must("30s"))]
+    timeout: DurationString,
 
     /// Maximum number of idle connections to maintain per host.
     #[arg(long, env = "MC_CONNECTIONS", default_value_t = NonZeroU64::new(4).unwrap())]
@@ -141,16 +146,17 @@ struct AddCommand {
 /// hundred bytes and 64KB.
 #[derive(Debug, Args)]
 struct BenchCommand {
-    /// How long to run the benchmark for in seconds.
-    #[arg(long, env = "MC_BENCH_TIME_SECS", default_value_t = NonZeroU64::new(60).unwrap())]
-    time_secs: NonZeroU64,
+    /// How long to run the benchmark for, in duration string format (value followed by units:
+    /// 'h', 'm', 's', 'ms', 'us', 'ns').
+    #[arg(long, env = "MC_BENCH_TIME", default_value_t = DurationString::must("60s"))]
+    time: DurationString,
 
     /// How many writes to the cache as a percentage of reads from the cache, 0 to 1.
     ///
     /// A value of `1.0` means that for 100 gets, there will be 100 sets. A value of `0.5`
     /// means that for 100 gets, there will be 50 sets. Default is to perform many more gets
     /// than sets since cache workloads tend to have more reads than writes.
-    #[arg(long, env = "MC_BENCH_WRITE_PERCENT", default_value_t = Percent::unchecked(0.05))]
+    #[arg(long, env = "MC_BENCH_WRITE_PERCENT", default_value_t = Percent::must(0.05))]
     write_percent: Percent,
 
     /// How many workers to run at once, performing gets and sets against the cache.
@@ -159,35 +165,39 @@ struct BenchCommand {
     #[arg(long, env = "MC_BENCH_CONCURRENCY", default_value_t = NonZeroUsize::new(1).unwrap())]
     concurrency: NonZeroUsize,
 
-    /// How long to wait between each batch of gets and sets performed against the cache.
+    /// How long to wait between each batch of gets and sets performed against the cache,
+    /// in duration string format (value followed by units: 'h', 'm', 's', 'ms', 'us', 'ns').
     ///
     /// Each batch is 1000 gets and 50 sets by default. With a delay of 100ms this means
     /// there will be 10,000 gets and 500 sets per second. To increase the number of gets
     /// and sets performed by a worker, reduce this number. To decrease the number of gets
     /// and sets performed by a worker, increase this number.
-    #[arg(long, env = "MC_BENCH_DELAY_MILLIS", default_value_t = NonZeroU64::new(100).unwrap())]
-    delay_millis: NonZeroU64,
+    #[arg(long, env = "MC_BENCH_DELAY", default_value_t = DurationString::must("100ms"))]
+    delay: DurationString,
 
-    /// TTL to use for test values stored in the cache in seconds.
-    #[arg(long, env = "MC_BENCH_TTL_SECS", default_value_t = 300)]
-    ttl_secs: u32,
+    /// TTL to use for test values stored in the cache, in duration string format (value
+    /// followed by units: 'h', 'm', 's', 'ms', 'us', 'ns').
+    #[arg(long, env = "MC_BENCH_TTL", default_value_t = DurationString::must("5m"))]
+    ttl: DurationString,
 }
 
 /// Run health checks against the cache.
 ///
-/// Checks will be run repeatedly with `delay-millis` in between each iteration until
-/// `time-secs` has elapsed. Time taken to do DNS resolution, connect, set a value in
-/// the cache, and get a value from the cache will be recorded and emitted as key-value
-/// pairs at the end of the test.
+/// Checks will be run repeatedly with `delay` in between each iteration until `time`
+/// has elapsed. Time taken to do DNS resolution, connect, set a value in the cache,
+/// and get a value from the cache will be recorded and emitted as key-value pairs at
+/// the end of the test.
 #[derive(Debug, Args)]
 struct CheckCommand {
-    /// How long to run the checks for in seconds.
-    #[arg(long, env = "MC_CHECK_TIME_SECS", default_value_t = NonZeroU64::new(60).unwrap())]
-    time_secs: NonZeroU64,
+    /// How long to run the checks for, in duration string format (value followed by units:
+    /// 'h', 'm', 's', 'ms', 'us', 'ns').
+    #[arg(long, env = "MC_CHECK_TIME", default_value_t = DurationString::must("60s"))]
+    time: DurationString,
 
-    /// How long to wait between each health check in milliseconds.
-    #[arg(long, env = "MC_CHECK_DELAY_MILLIS", default_value_t = NonZeroU64::new(100).unwrap())]
-    delay_millis: NonZeroU64,
+    /// How long to wait between each health check, in duration string format (value followed
+    /// by units: 'h', 'm', 's', 'ms', 'us', 'ns').
+    #[arg(long, env = "MC_CHECK_DELAY", default_value_t = DurationString::must("100ms"))]
+    delay: DurationString,
 }
 
 /// Decrement the value of an item in the cache.
@@ -215,12 +225,13 @@ struct DeleteCommand {
 /// Flush all entries from the cache, optionally after a delay.
 #[derive(Debug, Args)]
 struct FlushAllCommand {
-    /// How long to wait between flushing each server if there are multiple servers, in seconds.
-    /// If specified, each consecutive server will be scheduled to flush all entries this amount
-    /// of time after the previous server. For example, server S1 will flush at T = 0, S2 will flush
-    /// at T = wait_secs, S3 will flush at T = wait_secs * 2, S4 will flush at T = wait_secs * 3, etc.
-    #[arg(long, env = "MC_FLUSH_ALL_WAIT_SECS")]
-    wait_secs: Option<NonZeroU64>,
+    /// How long to wait between flushing each server if there are multiple servers, in duration
+    /// string format (value followed by units: 'h', 'm', 's', 'ms', 'us', 'ns'). If specified,
+    /// each consecutive server will be scheduled to flush all entries this amount of time after
+    /// the previous server. For example, server S1 will flush at T = 0, S2 will flush at T = wait,
+    /// S3 will flush at T = wait * 2, S4 will flush at T = wait * 3, etc.
+    #[arg(long, env = "MC_FLUSH_ALL_WAIT", default_value_t = DurationString::must("0s"))]
+    wait: DurationString,
 }
 
 /// Get the value of an item in the cache.
@@ -314,7 +325,7 @@ async fn main() -> ExitCode {
 
     let dns_client = mtop::dns::new_client(&opts.resolv_conf, None, None).await;
     let discovery = Discovery::new(dns_client);
-    let timeout = Duration::from_secs(opts.timeout_secs.get());
+    let timeout = opts.timeout.as_duration();
     let servers = match mtop::discovery::resolve_single(&opts.host, &discovery, timeout).await {
         Ok(v) => v,
         Err(e) => {
@@ -402,15 +413,15 @@ async fn run_bench(opts: &McConfig, cmd: &BenchCommand, client: MemcachedClient)
     let bencher = Bencher::new(
         client,
         Handle::current(),
-        Duration::from_millis(cmd.delay_millis.get()),
-        Duration::from_secs(opts.timeout_secs.get()),
-        Duration::from_secs(cmd.ttl_secs as u64),
+        cmd.delay.as_duration(),
+        opts.timeout.as_duration(),
+        cmd.ttl.as_duration(),
         cmd.write_percent,
         cmd.concurrency.get(),
         stop.clone(),
     );
 
-    let measurements = bencher.run(Duration::from_secs(cmd.time_secs.into())).await;
+    let measurements = bencher.run(cmd.time.as_duration()).await;
     print_bench_results(&measurements);
 
     ExitCode::SUCCESS
@@ -423,11 +434,11 @@ async fn run_check(opts: &McConfig, cmd: &CheckCommand, client: MemcachedClient,
     let checker = Checker::new(
         client,
         resolver,
-        Duration::from_millis(cmd.delay_millis.get()),
-        Duration::from_secs(opts.timeout_secs.get()),
+        cmd.delay.as_duration(),
+        opts.timeout.as_duration(),
         stop.clone(),
     );
-    let results = checker.run(&opts.host, Duration::from_secs(cmd.time_secs.get())).await;
+    let results = checker.run(&opts.host, cmd.time.as_duration()).await;
     print_check_results(&results);
 
     if results.failures.total > 0 {
@@ -466,9 +477,8 @@ async fn run_delete(opts: &McConfig, cmd: &DeleteCommand, client: &MemcachedClie
 }
 
 async fn run_flush_all(opts: &McConfig, cmd: &FlushAllCommand, client: &MemcachedClient) -> ExitCode {
-    let wait = cmd.wait_secs.map(|d| Duration::from_secs(d.get()));
     let response = match client
-        .flush_all(wait)
+        .flush_all(cmd.wait.as_duration())
         .timeout(Duration::from_secs(opts.timeout_secs.get()), "client.flush_all")
         .instrument(tracing::span!(Level::INFO, "client.flush_all"))
         .await

--- a/mtop/src/duration.rs
+++ b/mtop/src/duration.rs
@@ -1,0 +1,187 @@
+use mtop_client::MtopError;
+use std::fmt;
+use std::str::FromStr;
+use std::time::Duration;
+
+#[derive(Debug, Clone, Default)]
+pub struct DurationString {
+    parts: Vec<(u64, Unit)>,
+    total: Duration,
+}
+
+impl DurationString {
+    pub fn must(s: &str) -> Self {
+        s.parse().unwrap()
+    }
+
+    pub fn as_duration(&self) -> Duration {
+        self.total
+    }
+}
+
+impl FromStr for DurationString {
+    type Err = MtopError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let chunks: Vec<&str> = s
+            .as_bytes()
+            .chunk_by(|a, b| a.is_ascii_digit() == b.is_ascii_digit())
+            .flat_map(|v| str::from_utf8(v))
+            .collect();
+
+        if !chunks.len().is_multiple_of(2) {
+            return Err(MtopError::configuration(format!(
+                "all values must have a corresponding unit. got '{}'",
+                s
+            )));
+        }
+
+        let mut parts = Vec::with_capacity(chunks.len() / 2);
+        let mut total = Duration::ZERO;
+        let mut expect_val = true;
+        let mut last_val = 0;
+
+        for chunk in chunks {
+            if expect_val {
+                last_val = chunk
+                    .parse()
+                    .map_err(|e| MtopError::configuration_cause(format!("cannot parse {} from {}", chunk, s), e))?;
+                expect_val = false;
+            } else {
+                let unit: Unit = chunk.parse()?;
+                let duration = unit.as_duration(last_val)?;
+
+                total = total.checked_add(duration).ok_or_else(|| {
+                    MtopError::configuration(format!("{}{} in {} overflows max duration", last_val, unit, s))
+                })?;
+
+                parts.push((last_val, unit));
+                expect_val = true;
+            }
+        }
+
+        Ok(Self { parts, total })
+    }
+}
+
+impl fmt::Display for DurationString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (val, unit) in &self.parts {
+            val.fmt(f)?;
+            unit.fmt(f)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum Unit {
+    Hour,
+    Minute,
+    Second,
+    Millisecond,
+    Microsecond,
+    Nanosecond,
+}
+
+impl Unit {
+    const MAX_HOURS: u64 = u64::MAX / 3600;
+    const MAX_MINUTES: u64 = u64::MAX / 60;
+
+    fn as_duration(&self, val: u64) -> Result<Duration, MtopError> {
+        match self {
+            Unit::Hour => {
+                if val >= Self::MAX_HOURS {
+                    Err(MtopError::configuration(format!("overflowing value {}{}", val, self)))
+                } else {
+                    Ok(Duration::from_hours(val))
+                }
+            }
+            Unit::Minute => {
+                if val >= Self::MAX_MINUTES {
+                    Err(MtopError::configuration(format!("overflowing value {}{}", val, self)))
+                } else {
+                    Ok(Duration::from_mins(val))
+                }
+            }
+            Unit::Second => Ok(Duration::from_secs(val)),
+            Unit::Millisecond => Ok(Duration::from_millis(val)),
+            Unit::Microsecond => Ok(Duration::from_micros(val)),
+            Unit::Nanosecond => Ok(Duration::from_nanos(val)),
+        }
+    }
+}
+
+impl FromStr for Unit {
+    type Err = MtopError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "h" => Ok(Unit::Hour),
+            "m" => Ok(Unit::Minute),
+            "s" => Ok(Unit::Second),
+            "ms" => Ok(Unit::Millisecond),
+            "us" => Ok(Unit::Microsecond),
+            "ns" => Ok(Unit::Nanosecond),
+            _ => Err(MtopError::configuration(format!("invalid unit {}", s))),
+        }
+    }
+}
+
+impl fmt::Display for Unit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Unit::Hour => "h".fmt(f),
+            Unit::Minute => "m".fmt(f),
+            Unit::Second => "s".fmt(f),
+            Unit::Millisecond => "ms".fmt(f),
+            Unit::Microsecond => "us".fmt(f),
+            Unit::Nanosecond => "ns".fmt(f),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::DurationString;
+    use mtop_client::MtopError;
+    use std::time::Duration;
+
+    fn parse_to_duration(s: &str) -> Result<Duration, MtopError> {
+        let cfg = s.parse::<DurationString>()?;
+        Ok(cfg.as_duration())
+    }
+
+    #[test]
+    fn test_try_from_string_single_values() {
+        assert_eq!(Duration::from_nanos(5_000), parse_to_duration("5000ns").unwrap());
+        assert_eq!(Duration::from_micros(100), parse_to_duration("100us").unwrap());
+        assert_eq!(Duration::from_millis(200), parse_to_duration("200ms").unwrap());
+        assert_eq!(Duration::from_secs(90), parse_to_duration("90s").unwrap());
+        assert_eq!(Duration::from_mins(1), parse_to_duration("1m").unwrap());
+        assert_eq!(Duration::from_hours(1), parse_to_duration("1h").unwrap());
+    }
+
+    #[test]
+    fn test_try_from_string_multiple_values() {
+        assert_eq!(Duration::from_nanos(1_005_000), parse_to_duration("1ms5000ns").unwrap());
+        assert_eq!(Duration::from_micros(1_200), parse_to_duration("1ms200us").unwrap());
+        assert_eq!(Duration::from_millis(1500), parse_to_duration("1s500ms").unwrap());
+        assert_eq!(Duration::from_secs(90), parse_to_duration("1m30s").unwrap());
+        assert_eq!(Duration::from_mins(70), parse_to_duration("1h10m").unwrap());
+    }
+
+    #[test]
+    fn test_try_from_string_invalid_values() {
+        assert!(parse_to_duration("-12").is_err());
+        assert!(parse_to_duration("-3h").is_err());
+        assert!(parse_to_duration("asdf").is_err());
+        assert!(parse_to_duration("23").is_err());
+        assert!(parse_to_duration("1h7").is_err());
+        assert!(parse_to_duration("1y").is_err());
+        assert!(parse_to_duration("4d").is_err());
+        assert!(parse_to_duration("1🫠").is_err());
+        assert!(parse_to_duration("9999999999999999999h").is_err());
+    }
+}

--- a/mtop/src/lib.rs
+++ b/mtop/src/lib.rs
@@ -6,6 +6,7 @@ pub mod bench;
 pub mod check;
 pub mod discovery;
 pub mod dns;
+pub mod duration;
 pub mod ping;
 pub mod profile;
 pub mod queue;


### PR DESCRIPTION
Introduce a new type used for CLI flags that are durations modeled after Go's duration type. For example instead of the flag `--timeout-secs 5`, we'd use `--timeout 5s`.