### PR TITLE
refactor: implement URL decoding for meta k-v pairs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,6 +42,7 @@ jobs:
         include:
         - fuzz_target: fuzz_target_dns_message
         - fuzz_target: fuzz_target_dns_name
+        - fuzz_target: fuzz_target_memcached_codec
         - fuzz_target: fuzz_target_memcached_get
         - fuzz_target: fuzz_target_memcached_metas
         - fuzz_target: fuzz_target_memcached_stats

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,7 +627,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tracing",
- "urlencoding",
  "webpki-roots",
 ]
 
@@ -1401,12 +1400,6 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "uuid"

--- a/benches/Cargo.lock
+++ b/benches/Cargo.lock
@@ -84,6 +84,7 @@ dependencies = [
  "criterion",
  "mtop-client",
  "tokio",
+ "urlencoding",
 ]
 
 [[package]]
@@ -476,7 +477,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tracing",
- "urlencoding",
  "webpki-roots",
 ]
 

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -12,6 +12,7 @@ async-trait = "0.1.89"
 criterion = "0.5.1"
 mtop-client = { path = "../mtop-client" }
 tokio = { version = "1.14.0", features = ["full"] }
+urlencoding = "2.1.3"
 
 [[bench]]
 name = "dns_name"
@@ -26,6 +27,11 @@ harness = false
 [[bench]]
 name = "memcached_discovery"
 path = "memcached_discovery.rs"
+harness = false
+
+[[bench]]
+name = "memcached_codec"
+path = "memcached_codec.rs"
 harness = false
 
 [profile.release]

--- a/benches/memcached_codec.rs
+++ b/benches/memcached_codec.rs
@@ -1,0 +1,33 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+
+const SHORT_TEXT: &str = "a%20short%20sentence%3B";
+const LONG_TEXT: &str = "a%20long%20sentence%20that%20will%20require%20a%20fair%20bit%20of%20time%20to%20decode%2C%20on%20a%20relative%20scale%3B%20%26%20it%20should%20be%20a%20decent%20test%20of%20the%20%23%20of%20nano-seconds%20it%20takes%20for%20something%20like%20this%25";
+
+fn memcached_url_decode(c: &mut Criterion) {
+    c.bench_function("urlencoding::decode(short)", |b| {
+        b.iter(|| {
+            let _ = urlencoding::decode(SHORT_TEXT).unwrap();
+        });
+    });
+
+    c.bench_function("urlencoding::decode(long)", |b| {
+        b.iter(|| {
+            let _ = urlencoding::decode(LONG_TEXT).unwrap();
+        })
+    });
+
+    c.bench_function("mtop_client::url_decode(short)", |b| {
+        b.iter(|| {
+            let _ = mtop_client::url_decode(SHORT_TEXT).unwrap();
+        });
+    });
+
+    c.bench_function("mtop_client::url_decode(long)", |b| {
+        b.iter(|| {
+            let _ = mtop_client::url_decode(LONG_TEXT).unwrap();
+        })
+    });
+}
+
+criterion_group!(memcached_codec, memcached_url_decode);
+criterion_main!(memcached_codec);

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -571,7 +571,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tracing",
- "urlencoding",
  "webpki-roots",
 ]
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -46,6 +46,13 @@ doc = false
 bench = false
 
 [[bin]]
+name = "fuzz_target_memcached_codec"
+path = "fuzz_targets/memcached_codec.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
 name = "fuzz_target_memcached_stats"
 path = "fuzz_targets/memcached_stats.rs"
 test = false

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -21,6 +21,10 @@ cargo fuzz run fuzz_target_dns_name
 ```
 
 ```
+cargo fuzz run fuzz_target_memcached_codec
+```
+
+```
 cargo fuzz run fuzz_target_memcached_get
 ```
 

--- a/fuzz/fuzz_targets/memcached_codec.rs
+++ b/fuzz/fuzz_targets/memcached_codec.rs
@@ -1,0 +1,10 @@
+#![no_main]
+
+use libfuzzer_sys::{Corpus, fuzz_target};
+
+fuzz_target!(|data: String| -> Corpus {
+    match mtop_client::url_decode(&data) {
+        Ok(_v) => Corpus::Keep,
+        Err(_e) => Corpus::Reject,
+    }
+});

--- a/mtop-client/Cargo.toml
+++ b/mtop-client/Cargo.toml
@@ -19,7 +19,6 @@ rustls-pki-types = {  version = "1.14.0", features = ["std"]}
 tokio = { version = "1.45.1", features = ["full"] }
 tokio-rustls = { version = "0.26.4", default-features = false, features = ["ring", "tls12"] }
 tracing = "0.1.44"
-urlencoding = "2.1.3"
 webpki-roots = "1.0.7"
 
 [lib]

--- a/mtop-client/src/codec.rs
+++ b/mtop-client/src/codec.rs
@@ -1,0 +1,134 @@
+use crate::core::MtopError;
+
+/// Convert the string representation of a hex digit to the actual digit.
+fn hex_to_digit(hex: u8) -> Option<u8> {
+    match hex {
+        b'0'..=b'9' => Some(hex - b'0'),
+        b'A'..=b'F' => Some(hex - b'A' + 10),
+        b'a'..=b'f' => Some(hex - b'a' + 10),
+        _ => None,
+    }
+}
+
+/// Decode a percent-encoded (aka URL-encoded) string.
+///
+/// Incomplete or invalid encodings are included in the decoded string verbatim.
+///
+/// # Example
+/// ```
+/// # use mtop_client::url_decode;
+/// assert_eq!("no-encoding", url_decode("no-encoding").unwrap());
+/// assert_eq!("either/or", url_decode("either%2For").unwrap());
+/// assert_eq!("have not", url_decode("have%20not").unwrap());
+/// assert_eq!("up by 10%", url_decode("up%20by%2010%25").unwrap());
+/// assert_eq!("invalid%2%encoding", url_decode("invalid%2%encoding").unwrap());
+/// ```
+pub fn url_decode(s: &str) -> Result<String, MtopError> {
+    // Short-circuit for a fairly common case, this string isn't actually URL encoded.
+    if !s.contains('%') {
+        return Ok(s.to_owned());
+    }
+
+    let mut out = Vec::with_capacity(s.len());
+    let mut data = s.as_bytes();
+    loop {
+        let mut parts = data.splitn(2, |&b| b == b'%');
+
+        // Append anything preceding the '%' with a single call to the output slice instead
+        // of looping over the entire input one byte at a time.
+        if let Some(plain) = parts.next() {
+            out.extend_from_slice(plain);
+        }
+
+        // A 'None' remainder means there was no '%' and we've finished parsing the input.
+        let remainder = parts.next();
+        if remainder.is_none() {
+            break;
+        }
+
+        data = remainder.unwrap();
+        // An empty slice remainder means there was a trailing '%' on the input so we need
+        // to add it to the output before returning.
+        if data.is_empty() {
+            out.push(b'%');
+            break;
+        }
+
+        let char1 = data[0];
+        let Some(digit1) = hex_to_digit(char1) else {
+            // Not a valid escape sequence. Add anything we've already consumed to
+            // the output before moving on to the next iteration of the parsing loop.
+            out.push(b'%');
+            continue;
+        };
+
+        data = &data[1..];
+        if data.is_empty() {
+            // If we're aborting early, add anything we've already consumed to the output.
+            out.push(b'%');
+            out.push(char1);
+            break;
+        }
+
+        let char2 = data[0];
+        let Some(digit2) = hex_to_digit(char2) else {
+            // Not a valid escape sequence. Add anything we've already consumed to
+            // the output before moving on to the next iteration of the parsing loop.
+            out.push(b'%');
+            out.push(char1);
+            continue;
+        };
+
+        let c = digit1 << 4 | digit2;
+        out.push(c);
+
+        data = &data[1..];
+    }
+
+    String::from_utf8(out).map_err(|e| MtopError::runtime_cause(format!("invalid url encoding in '{}'", s), e))
+}
+
+#[cfg(test)]
+mod test {
+    use super::url_decode;
+
+    #[test]
+    fn test_url_decode_simple() {
+        assert_eq!("no-encoding", url_decode("no-encoding").unwrap());
+        assert_eq!("either/or", url_decode("either%2for").unwrap());
+        assert_eq!("some code", url_decode("some%20code").unwrap());
+        assert_eq!("sugar&spice", url_decode("sugar%26spice").unwrap());
+        assert_eq!("x!=y", url_decode("x%21%3Dy").unwrap());
+    }
+
+    #[test]
+    fn test_url_decode_emoji() {
+        assert_eq!(
+            "🫠 this is fine",
+            url_decode("%F0%9F%AB%A0%20this%20is%20fine").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_url_decode_unencoded_emoji_skipped() {
+        assert_eq!("🫠 this is fine", url_decode("🫠 this is fine").unwrap());
+    }
+
+    #[test]
+    fn test_url_decode_broken_encoding() {
+        assert_eq!("some code", url_decode("some%20code").unwrap());
+        assert_eq!("some code%", url_decode("some%20code%").unwrap());
+        assert_eq!("some code%2", url_decode("some%20code%2").unwrap());
+        assert_eq!("some code%%", url_decode("some%20code%%").unwrap());
+        assert_eq!("some code ", url_decode("some%20code%20").unwrap());
+        assert_eq!("some code%2G", url_decode("some%20code%2G").unwrap());
+    }
+
+    #[test]
+    fn test_url_decode_invalid_utf8() {
+        assert!(
+            url_decode("%FF").is_err(),
+            "expected invalid utf-8 byte 0xFF to be an error"
+        );
+    }
+}

--- a/mtop-client/src/core.rs
+++ b/mtop-client/src/core.rs
@@ -910,9 +910,8 @@ impl Memcached {
                 continue;
             }
 
-            let decoded = urlencoding::decode(val)
-                .map_err(|e| MtopError::runtime_cause(format!("unexpected metadump encoding '{}'", line), e))?;
-            raw.insert(key.to_owned(), decoded.into_owned());
+            let decoded = crate::codec::url_decode(val)?;
+            raw.insert(key.to_owned(), decoded);
         }
 
         Meta::try_from(&*raw)

--- a/mtop-client/src/lib.rs
+++ b/mtop-client/src/lib.rs
@@ -10,6 +10,7 @@
 #![deny(unused_must_use)]
 
 mod client;
+mod codec;
 mod core;
 mod discovery;
 pub mod dns;
@@ -23,6 +24,7 @@ pub use crate::client::{
     MemcachedClient, MemcachedClientConfig, RendezvousSelector, Selector, ServersResponse, TcpClientFactory,
     TlsTcpClientFactory, ValuesResponse,
 };
+pub use crate::codec::url_decode;
 pub use crate::core::{
     ErrorKind, Key, Memcached, Meta, MtopError, ProtocolError, ProtocolErrorKind, Slab, SlabItem, SlabItems, Slabs,
     Stats, Value,


### PR DESCRIPTION
Instead of pulling in a library to do it, implement it ourselves.