### PR TITLE
refactor: remove dependency on byteorder crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,12 +104,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,7 +614,6 @@ name = "mtop-client"
 version = "0.16.2"
 dependencies = [
  "async-trait",
- "byteorder",
  "pin-project-lite",
  "rand",
  "rustls-pki-types",

--- a/benches/Cargo.lock
+++ b/benches/Cargo.lock
@@ -99,12 +99,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,7 +463,6 @@ name = "mtop-client"
 version = "0.16.2"
 dependencies = [
  "async-trait",
- "byteorder",
  "pin-project-lite",
  "rand",
  "rustls-pki-types",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -83,12 +83,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,7 +557,6 @@ name = "mtop-client"
 version = "0.16.2"
 dependencies = [
  "async-trait",
- "byteorder",
  "pin-project-lite",
  "rand",
  "rustls-pki-types",

--- a/mtop-client/Cargo.toml
+++ b/mtop-client/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2024"
 
 [dependencies]
 async-trait = "0.1.89"
-byteorder = "1.5.0"
 pin-project-lite = "0.2.16"
 rand = "0.10.1"
 rustls-pki-types = {  version = "1.14.0", features = ["std"]}

--- a/mtop-client/src/dns/bytes.rs
+++ b/mtop-client/src/dns/bytes.rs
@@ -1,0 +1,50 @@
+use crate::core::MtopError;
+use std::io::{Read, Write};
+
+pub(crate) fn read_be_u8<R>(reader: &mut R) -> Result<u8, MtopError>
+where
+    R: Read,
+{
+    let mut buf = [0; 1];
+    reader.read_exact(&mut buf)?;
+    Ok(buf[0])
+}
+
+pub(crate) fn read_be_u16<R>(reader: &mut R) -> Result<u16, MtopError>
+where
+    R: Read,
+{
+    let mut buf = [0; 2];
+    reader.read_exact(&mut buf)?;
+    Ok(u16::from_be_bytes(buf[..2].try_into().unwrap()))
+}
+
+pub(crate) fn read_be_u32<R>(reader: &mut R) -> Result<u32, MtopError>
+where
+    R: Read,
+{
+    let mut buf = [0; 4];
+    reader.read_exact(&mut buf)?;
+    Ok(u32::from_be_bytes(buf[..4].try_into().unwrap()))
+}
+
+pub(crate) fn write_be_u8<W>(writer: &mut W, b: u8) -> Result<(), MtopError>
+where
+    W: Write,
+{
+    Ok(writer.write_all(&[b])?)
+}
+
+pub(crate) fn write_be_u16<W>(writer: &mut W, b: u16) -> Result<(), MtopError>
+where
+    W: Write,
+{
+    Ok(writer.write_all(&b.to_be_bytes())?)
+}
+
+pub(crate) fn write_be_u32<W>(writer: &mut W, b: u32) -> Result<(), MtopError>
+where
+    W: Write,
+{
+    Ok(writer.write_all(&b.to_be_bytes())?)
+}

--- a/mtop-client/src/dns/message.rs
+++ b/mtop-client/src/dns/message.rs
@@ -1,10 +1,10 @@
 use crate::core::MtopError;
+use crate::dns::bytes::{read_be_u16, read_be_u32, write_be_u16, write_be_u32};
 use crate::dns::core::{RecordClass, RecordType};
 use crate::dns::name::Name;
 use crate::dns::rdata::RecordData;
-use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
 use std::fmt;
-use std::io::Seek;
+use std::io::{Read, Seek, Write};
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 #[repr(transparent)]
@@ -148,7 +148,7 @@ impl Message {
 
     pub fn write_network_bytes<T>(&self, mut buf: T) -> Result<(), MtopError>
     where
-        T: WriteBytesExt,
+        T: Write,
     {
         let header = self.header();
         header.write_network_bytes(&mut buf)?;
@@ -174,7 +174,7 @@ impl Message {
 
     pub fn read_network_bytes<T>(mut buf: T) -> Result<Self, MtopError>
     where
-        T: ReadBytesExt + Seek,
+        T: Read + Seek,
     {
         let header = Header::read_network_bytes(&mut buf)?;
 
@@ -222,26 +222,26 @@ struct Header {
 impl Header {
     fn write_network_bytes<T>(&self, mut buf: T) -> Result<(), MtopError>
     where
-        T: WriteBytesExt,
+        T: Write,
     {
-        buf.write_u16::<NetworkEndian>(self.id.into())?;
-        buf.write_u16::<NetworkEndian>(self.flags.as_u16())?;
-        buf.write_u16::<NetworkEndian>(self.num_questions)?;
-        buf.write_u16::<NetworkEndian>(self.num_answers)?;
-        buf.write_u16::<NetworkEndian>(self.num_authority)?;
-        Ok(buf.write_u16::<NetworkEndian>(self.num_extra)?)
+        write_be_u16(&mut buf, self.id.into())?;
+        write_be_u16(&mut buf, self.flags.as_u16())?;
+        write_be_u16(&mut buf, self.num_questions)?;
+        write_be_u16(&mut buf, self.num_answers)?;
+        write_be_u16(&mut buf, self.num_authority)?;
+        write_be_u16(&mut buf, self.num_extra)
     }
 
     fn read_network_bytes<T>(mut buf: T) -> Result<Self, MtopError>
     where
-        T: ReadBytesExt,
+        T: Read,
     {
-        let id = MessageId::from(buf.read_u16::<NetworkEndian>()?);
-        let flags = Flags::try_from(buf.read_u16::<NetworkEndian>()?)?;
-        let num_questions = buf.read_u16::<NetworkEndian>()?;
-        let num_answers = buf.read_u16::<NetworkEndian>()?;
-        let num_authority = buf.read_u16::<NetworkEndian>()?;
-        let num_extra = buf.read_u16::<NetworkEndian>()?;
+        let id = MessageId::from(read_be_u16(&mut buf)?);
+        let flags = Flags::try_from(read_be_u16(&mut buf)?)?;
+        let num_questions = read_be_u16(&mut buf)?;
+        let num_answers = read_be_u16(&mut buf)?;
+        let num_authority = read_be_u16(&mut buf)?;
+        let num_extra = read_be_u16(&mut buf)?;
 
         Ok(Header {
             id,
@@ -506,20 +506,20 @@ impl Question {
 
     pub fn write_network_bytes<T>(&self, mut buf: T) -> Result<(), MtopError>
     where
-        T: WriteBytesExt,
+        T: Write,
     {
         self.name.write_network_bytes(&mut buf)?;
-        buf.write_u16::<NetworkEndian>(self.qtype.into())?;
-        Ok(buf.write_u16::<NetworkEndian>(self.qclass.into())?)
+        write_be_u16(&mut buf, self.qtype.into())?;
+        write_be_u16(&mut buf, self.qclass.into())
     }
 
     pub fn read_network_bytes<T>(mut buf: T) -> Result<Self, MtopError>
     where
-        T: ReadBytesExt + Seek,
+        T: Read + Seek,
     {
         let name = Name::read_network_bytes(&mut buf)?;
-        let qtype = RecordType::from(buf.read_u16::<NetworkEndian>()?);
-        let qclass = RecordClass::from(buf.read_u16::<NetworkEndian>()?);
+        let qtype = RecordType::from(read_be_u16(&mut buf)?);
+        let qclass = RecordClass::from(read_be_u16(&mut buf)?);
         Ok(Self { name, qtype, qclass })
     }
 }
@@ -575,7 +575,7 @@ impl Record {
 
     pub fn write_network_bytes<T>(&self, mut buf: T) -> Result<(), MtopError>
     where
-        T: WriteBytesExt,
+        T: Write,
     {
         // It shouldn't be possible for rdata to overflow u16 so if we do, that's a bug.
         let size = self.rdata.size();
@@ -587,22 +587,22 @@ impl Record {
         );
 
         self.name.write_network_bytes(&mut buf)?;
-        buf.write_u16::<NetworkEndian>(self.rtype.into())?;
-        buf.write_u16::<NetworkEndian>(self.rclass.into())?;
-        buf.write_u32::<NetworkEndian>(self.ttl)?;
-        buf.write_u16::<NetworkEndian>(u16::try_from(size).unwrap())?;
+        write_be_u16(&mut buf, self.rtype.into())?;
+        write_be_u16(&mut buf, self.rclass.into())?;
+        write_be_u32(&mut buf, self.ttl)?;
+        write_be_u16(&mut buf, u16::try_from(size).unwrap())?;
         self.rdata.write_network_bytes(&mut buf)
     }
 
     pub fn read_network_bytes<T>(mut buf: T) -> Result<Self, MtopError>
     where
-        T: ReadBytesExt + Seek,
+        T: Read + Seek,
     {
         let name = Name::read_network_bytes(&mut buf)?;
-        let rtype = RecordType::from(buf.read_u16::<NetworkEndian>()?);
-        let rclass = RecordClass::from(buf.read_u16::<NetworkEndian>()?);
-        let ttl = buf.read_u32::<NetworkEndian>()?;
-        let rdata_len = buf.read_u16::<NetworkEndian>()?;
+        let rtype = RecordType::from(read_be_u16(&mut buf)?);
+        let rclass = RecordClass::from(read_be_u16(&mut buf)?);
+        let ttl = read_be_u32(&mut buf)?;
+        let rdata_len = read_be_u16(&mut buf)?;
         let rdata = RecordData::read_network_bytes(rtype, rdata_len, &mut buf)?;
 
         Ok(Self {

--- a/mtop-client/src/dns/mod.rs
+++ b/mtop-client/src/dns/mod.rs
@@ -1,3 +1,4 @@
+mod bytes;
 mod client;
 mod core;
 mod message;

--- a/mtop-client/src/dns/name.rs
+++ b/mtop-client/src/dns/name.rs
@@ -1,7 +1,7 @@
 use crate::core::MtopError;
-use byteorder::{ReadBytesExt, WriteBytesExt};
+use crate::dns::bytes::{read_be_u8, write_be_u8};
 use std::fmt;
-use std::io::{Read, Seek, SeekFrom};
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::str::FromStr;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -56,7 +56,7 @@ impl Name {
 
     pub fn write_network_bytes<T>(&self, mut out: T) -> Result<(), MtopError>
     where
-        T: WriteBytesExt,
+        T: Write,
     {
         // We convert all incoming Names to fully qualified names. If we missed doing
         // that, it's a bug and we should panic here. Encoded names all end with the
@@ -82,16 +82,16 @@ impl Name {
                 Self::MAX_LABEL_LENGTH
             );
 
-            out.write_u8(u8::try_from(label.len()).unwrap())?;
+            write_be_u8(&mut out, u8::try_from(label.len()).unwrap())?;
             out.write_all(label)?;
         }
 
-        Ok(out.write_u8(0)?)
+        write_be_u8(&mut out, 0)
     }
 
     pub fn read_network_bytes<T>(mut inp: T) -> Result<Self, MtopError>
     where
-        T: ReadBytesExt + Seek,
+        T: Read + Seek,
     {
         let mut labels = Vec::with_capacity(Self::NUM_LABELS_HINT);
         Self::read_inner(&mut inp, &mut labels)?;
@@ -104,7 +104,7 @@ impl Name {
     /// of each label is written into a `Vec<u8>`.
     fn read_inner<T>(inp: &mut T, out: &mut Vec<Vec<u8>>) -> Result<(), MtopError>
     where
-        T: ReadBytesExt + Seek,
+        T: Read + Seek,
     {
         let mut total_len = 0;
         let mut pointers = 0;
@@ -120,13 +120,13 @@ impl Name {
                 )));
             }
 
-            let len = inp.read_u8()?;
+            let len = read_be_u8(inp)?;
             // If the length isn't a length but actually a pointer to another name
             // or label within the message, seek to that position within the message
             // and read the name from there. After resolving all pointers and reading
             // labels, reset the stream back to immediately after the first pointer.
             if Self::is_compressed_label(len) {
-                let offset = Self::get_offset(len, inp.read_u8()?);
+                let offset = Self::get_offset(len, read_be_u8(inp)?);
                 if position.is_none() {
                     position = Some(inp.stream_position()?);
                 }
@@ -162,7 +162,7 @@ impl Name {
     /// `out` and return false, true if next label was the root.
     fn read_label_into<T>(inp: &mut T, total_len: usize, len: u8, out: &mut Vec<u8>) -> Result<bool, MtopError>
     where
-        T: ReadBytesExt + Seek,
+        T: Read + Seek,
     {
         if len == 0 {
             return Ok(true);

--- a/mtop-client/src/dns/rdata.rs
+++ b/mtop-client/src/dns/rdata.rs
@@ -1,9 +1,9 @@
 use crate::core::MtopError;
+use crate::dns::bytes::{read_be_u8, read_be_u16, read_be_u32, write_be_u8, write_be_u16, write_be_u32};
 use crate::dns::core::RecordType;
 use crate::dns::name::Name;
-use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
 use std::fmt::{self, Display};
-use std::io::{Read, Seek};
+use std::io::{Read, Seek, Write};
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -36,7 +36,7 @@ impl RecordData {
 
     pub fn write_network_bytes<T>(&self, buf: T) -> Result<(), MtopError>
     where
-        T: WriteBytesExt,
+        T: Write,
     {
         match self {
             Self::A(rd) => rd.write_network_bytes(buf),
@@ -53,7 +53,7 @@ impl RecordData {
 
     pub fn read_network_bytes<T>(rtype: RecordType, rdata_len: u16, buf: T) -> Result<Self, MtopError>
     where
-        T: ReadBytesExt + Seek,
+        T: Read + Seek,
     {
         match rtype {
             RecordType::A => Ok(RecordData::A(RecordDataA::read_network_bytes(buf)?)),
@@ -105,14 +105,14 @@ impl RecordDataA {
 
     pub fn write_network_bytes<T>(&self, mut buf: T) -> Result<(), MtopError>
     where
-        T: WriteBytesExt,
+        T: Write,
     {
         Ok(buf.write_all(&self.0.octets())?)
     }
 
     pub fn read_network_bytes<T>(mut buf: T) -> Result<Self, MtopError>
     where
-        T: ReadBytesExt + Seek,
+        T: Read + Seek,
     {
         let mut bytes = [0_u8; 4];
         buf.read_exact(&mut bytes)?;
@@ -144,14 +144,14 @@ impl RecordDataNS {
 
     pub fn write_network_bytes<T>(&self, buf: T) -> Result<(), MtopError>
     where
-        T: WriteBytesExt,
+        T: Write,
     {
         self.0.write_network_bytes(buf)
     }
 
     pub fn read_network_bytes<T>(buf: T) -> Result<Self, MtopError>
     where
-        T: ReadBytesExt + Seek,
+        T: Read + Seek,
     {
         Ok(Self::new(Name::read_network_bytes(buf)?))
     }
@@ -181,14 +181,14 @@ impl RecordDataCNAME {
 
     pub fn write_network_bytes<T>(&self, buf: T) -> Result<(), MtopError>
     where
-        T: WriteBytesExt,
+        T: Write,
     {
         self.0.write_network_bytes(buf)
     }
 
     pub fn read_network_bytes<T>(buf: T) -> Result<Self, MtopError>
     where
-        T: ReadBytesExt + Seek,
+        T: Read + Seek,
     {
         Ok(Self::new(Name::read_network_bytes(buf)?))
     }
@@ -257,29 +257,29 @@ impl RecordDataSOA {
 
     pub fn write_network_bytes<T>(&self, mut buf: T) -> Result<(), MtopError>
     where
-        T: WriteBytesExt,
+        T: Write,
     {
         self.mname.write_network_bytes(&mut buf)?;
         self.rname.write_network_bytes(&mut buf)?;
-        buf.write_u32::<NetworkEndian>(self.serial)?;
-        buf.write_u32::<NetworkEndian>(self.refresh)?;
-        buf.write_u32::<NetworkEndian>(self.retry)?;
-        buf.write_u32::<NetworkEndian>(self.expire)?;
-        buf.write_u32::<NetworkEndian>(self.minimum)?;
+        write_be_u32(&mut buf, self.serial)?;
+        write_be_u32(&mut buf, self.refresh)?;
+        write_be_u32(&mut buf, self.retry)?;
+        write_be_u32(&mut buf, self.expire)?;
+        write_be_u32(&mut buf, self.minimum)?;
         Ok(())
     }
 
     pub fn read_network_bytes<T>(mut buf: T) -> Result<Self, MtopError>
     where
-        T: ReadBytesExt + Seek,
+        T: Read + Seek,
     {
         let mname = Name::read_network_bytes(&mut buf)?;
         let rname = Name::read_network_bytes(&mut buf)?;
-        let serial = buf.read_u32::<NetworkEndian>()?;
-        let refresh = buf.read_u32::<NetworkEndian>()?;
-        let retry = buf.read_u32::<NetworkEndian>()?;
-        let expire = buf.read_u32::<NetworkEndian>()?;
-        let minimum = buf.read_u32::<NetworkEndian>()?;
+        let serial = read_be_u32(&mut buf)?;
+        let refresh = read_be_u32(&mut buf)?;
+        let retry = read_be_u32(&mut buf)?;
+        let expire = read_be_u32(&mut buf)?;
+        let minimum = read_be_u32(&mut buf)?;
 
         Ok(Self::new(mname, rname, serial, refresh, retry, expire, minimum))
     }
@@ -350,7 +350,7 @@ impl RecordDataTXT {
 
     pub fn write_network_bytes<T>(&self, mut buf: T) -> Result<(), MtopError>
     where
-        T: WriteBytesExt,
+        T: Write,
     {
         for txt in &self.0 {
             assert!(
@@ -360,7 +360,7 @@ impl RecordDataTXT {
                 Self::MAX_SEGMENT_LENGTH,
             );
 
-            buf.write_u8(u8::try_from(txt.len()).unwrap())?;
+            write_be_u8(&mut buf, u8::try_from(txt.len()).unwrap())?;
             buf.write_all(txt)?;
         }
 
@@ -369,14 +369,14 @@ impl RecordDataTXT {
 
     pub fn read_network_bytes<T>(rdata_len: u16, mut buf: T) -> Result<Self, MtopError>
     where
-        T: ReadBytesExt + Seek,
+        T: Read + Seek,
     {
         let rdata_len = usize::from(rdata_len);
         let mut all = Vec::new();
         let mut consumed = 0;
 
         while consumed < rdata_len {
-            let len = buf.read_u8()?;
+            let len = read_be_u8(&mut buf)?;
             if usize::from(len) + consumed > rdata_len {
                 return Err(MtopError::runtime(format!(
                     "text for RecordDataTXT exceeds rdata size; len: {}, consumed: {}, rdata: {}",
@@ -435,14 +435,14 @@ impl RecordDataAAAA {
 
     pub fn write_network_bytes<T>(&self, mut buf: T) -> Result<(), MtopError>
     where
-        T: WriteBytesExt,
+        T: Write,
     {
         Ok(buf.write_all(&self.0.octets())?)
     }
 
     pub fn read_network_bytes<T>(mut buf: T) -> Result<Self, MtopError>
     where
-        T: ReadBytesExt + Seek,
+        T: Read + Seek,
     {
         let mut bytes = [0_u8; 16];
         buf.read_exact(&mut bytes)?;
@@ -496,21 +496,21 @@ impl RecordDataSRV {
 
     pub fn write_network_bytes<T>(&self, mut buf: T) -> Result<(), MtopError>
     where
-        T: WriteBytesExt,
+        T: Write,
     {
-        buf.write_u16::<NetworkEndian>(self.priority)?;
-        buf.write_u16::<NetworkEndian>(self.weight)?;
-        buf.write_u16::<NetworkEndian>(self.port)?;
+        write_be_u16(&mut buf, self.priority)?;
+        write_be_u16(&mut buf, self.weight)?;
+        write_be_u16(&mut buf, self.port)?;
         self.target.write_network_bytes(buf)
     }
 
     pub fn read_network_bytes<T>(mut buf: T) -> Result<Self, MtopError>
     where
-        T: ReadBytesExt + Seek,
+        T: Read + Seek,
     {
-        let priority = buf.read_u16::<NetworkEndian>()?;
-        let weight = buf.read_u16::<NetworkEndian>()?;
-        let port = buf.read_u16::<NetworkEndian>()?;
+        let priority = read_be_u16(&mut buf)?;
+        let weight = read_be_u16(&mut buf)?;
+        let port = read_be_u16(&mut buf)?;
         let target = Name::read_network_bytes(buf)?;
 
         Ok(Self::new(priority, weight, port, target))
@@ -558,7 +558,7 @@ impl RecordDataOptPair {
 
     fn write_network_bytes<T>(&self, mut buf: T) -> Result<(), MtopError>
     where
-        T: WriteBytesExt,
+        T: Write,
     {
         assert!(
             self.data.len() <= Self::MAX_DATA_LENGTH,
@@ -567,17 +567,17 @@ impl RecordDataOptPair {
             Self::MAX_DATA_LENGTH,
         );
 
-        buf.write_u16::<NetworkEndian>(self.code)?;
-        buf.write_u16::<NetworkEndian>(u16::try_from(self.data.len()).unwrap())?;
+        write_be_u16(&mut buf, self.code)?;
+        write_be_u16(&mut buf, u16::try_from(self.data.len()).unwrap())?;
         Ok(buf.write_all(&self.data)?)
     }
 
     fn read_network_bytes<T>(mut buf: T) -> Result<Self, MtopError>
     where
-        T: ReadBytesExt + Seek,
+        T: Read + Seek,
     {
-        let code = buf.read_u16::<NetworkEndian>()?;
-        let data_len = buf.read_u16::<NetworkEndian>()?;
+        let code = read_be_u16(&mut buf)?;
+        let data_len = read_be_u16(&mut buf)?;
         let mut data = Vec::with_capacity(usize::from(data_len));
         buf.take(u64::from(data_len)).read_to_end(&mut data)?;
         Ok(Self { code, data })
@@ -625,7 +625,7 @@ impl RecordDataOpt {
 
     pub fn write_network_bytes<T>(&self, mut buf: T) -> Result<(), MtopError>
     where
-        T: WriteBytesExt,
+        T: Write,
     {
         for opt in &self.options {
             opt.write_network_bytes(&mut buf)?;
@@ -636,7 +636,7 @@ impl RecordDataOpt {
 
     pub fn read_network_bytes<T>(rdata_len: u16, mut buf: T) -> Result<Self, MtopError>
     where
-        T: ReadBytesExt + Seek,
+        T: Read + Seek,
     {
         let rdata_len = usize::from(rdata_len);
         let mut options = Vec::new();
@@ -686,7 +686,7 @@ impl RecordDataUnknown {
 
     pub fn write_network_bytes<T>(&self, mut buf: T) -> Result<(), MtopError>
     where
-        T: WriteBytesExt,
+        T: Write,
     {
         buf.write_all(&self.0)?;
         Ok(())
@@ -694,7 +694,7 @@ impl RecordDataUnknown {
 
     pub fn read_network_bytes<T>(rdata_len: u16, buf: T) -> Result<Self, MtopError>
     where
-        T: ReadBytesExt + Seek,
+        T: Read + Seek,
     {
         let mut bytes = Vec::with_capacity(usize::from(rdata_len));
         let n = buf.take(u64::from(rdata_len)).read_to_end(&mut bytes)?;

--- a/mtop-client/src/dns/test.rs
+++ b/mtop-client/src/dns/test.rs
@@ -1,9 +1,9 @@
 use crate::core::MtopError;
+use crate::dns::bytes::{read_be_u16, write_be_u16};
 use crate::dns::client::{TcpConnection, UdpConnection};
 use crate::dns::message::Message;
 use crate::pool::ClientFactory;
 use async_trait::async_trait;
-use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
 use std::collections::HashMap;
 use std::io::{Cursor, Error};
 use std::net::SocketAddr;
@@ -88,7 +88,8 @@ impl AsyncRead for TestTcpSocket {
         let size = msg.size();
 
         let mut bytes = Vec::new();
-        bytes.write_u16::<NetworkEndian>(u16::try_from(size).unwrap()).unwrap();
+
+        write_be_u16(&mut bytes, u16::try_from(size).unwrap()).unwrap();
         msg.write_network_bytes(&mut bytes).unwrap();
         assert_eq!(bytes.len(), size + 2);
 
@@ -100,7 +101,7 @@ impl AsyncRead for TestTcpSocket {
 impl AsyncWrite for TestTcpSocket {
     fn poll_write(self: Pin<&mut Self>, _cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, Error>> {
         let mut cur = Cursor::new(buf);
-        let size = usize::from(cur.read_u16::<NetworkEndian>().unwrap());
+        let size = usize::from(read_be_u16(&mut cur).unwrap());
         let msg = Message::read_network_bytes(cur).unwrap();
         assert_eq!(size, msg.size());
 


### PR DESCRIPTION
We only use a small bit of it and only ever deal with network order bytes. Implement the few required methods ourselves instead of pulling in a dependency.