### PR TITLE
fix: set max payload size for `mc` storage commands

### DIFF
--- a/mtop-client/src/core.rs
+++ b/mtop-client/src/core.rs
@@ -686,7 +686,7 @@ pub struct Memcached {
 }
 
 impl Memcached {
-    const MAX_PAYLOAD_SIZE: u64 = 1024 * 1024 * 1024;
+    pub const MAX_PAYLOAD_SIZE: u64 = 1024 * 1024 * 1024;
 
     pub fn new<R, W>(read: R, write: W) -> Self
     where
@@ -929,11 +929,10 @@ impl Memcached {
                 let len: u64 = parse_value(len, line)?;
                 let cas: u64 = parse_value(cas, line)?;
 
-                // The max size of an object in Memcached is represented with a `u64` which
-                // means it's basically infinite. In practice the default max size of an object
-                // in a Memcached server is 1MB but can be configured higher. Place a limit on
-                // the size that we'll accept here to avoid a denial of service from bad lengths.
-                if len > Self::MAX_PAYLOAD_SIZE {
+                // The default max size of an object in Memcached is 1MB and the max-max size is
+                // 1024MB. Place a 1024MB limit on the size that we'll accept here to avoid a denial
+                // of service from bad lengths.
+                if len >= Self::MAX_PAYLOAD_SIZE {
                     return Err(MtopError::runtime(format!(
                         "server response of length {} exceeds client max of {}",
                         len,

--- a/mtop/src/bin/mc.rs
+++ b/mtop/src/bin/mc.rs
@@ -2,7 +2,7 @@ use clap::{Args, Parser, Subcommand, ValueHint};
 use mtop::bench::{Bencher, Percent, Summary};
 use mtop::check::{Bundle, Checker};
 use mtop::duration::DurationString;
-use mtop_client::{Discovery, MemcachedClient, Meta, MtopError, Timeout, TlsConfig, Value};
+use mtop_client::{Discovery, Memcached, MemcachedClient, Meta, MtopError, Timeout, TlsConfig, Value};
 use rustls_pki_types::{InvalidDnsNameError, ServerName};
 use std::num::{NonZeroU64, NonZeroUsize};
 use std::path::PathBuf;
@@ -110,7 +110,7 @@ enum Action {
 /// Add a value to the cache only if it does not already exist.
 ///
 /// The value will be read from standard input. You can use shell pipes or redirects to set
-/// the contents of files as values.
+/// the contents of files as values. Up to 1GB will be read, any bytes after this are ignored.
 #[derive(Debug, Args)]
 struct AddCommand {
     /// Key of the item to add the value for.
@@ -259,7 +259,7 @@ struct KeysCommand {
 /// Replace a value in the cache only if it already exists.
 ///
 /// The value will be read from standard input. You can use shell pipes or redirects to set
-/// the contents of files as values.
+/// the contents of files as values. Up to 1GB will be read, any bytes after this are ignored.
 #[derive(Debug, Args)]
 struct ReplaceCommand {
     /// Key of the item to replace the value for.
@@ -276,7 +276,7 @@ struct ReplaceCommand {
 /// Set a value in the cache.
 ///
 /// The value will be read from standard input. You can use shell pipes or redirects to set
-/// the contents of files as values.
+/// the contents of files as values. Up to 1GB will be read, any bytes after this are ignored.
 #[derive(Debug, Args)]
 struct SetCommand {
     /// Key of the item to set the value for.
@@ -634,7 +634,7 @@ async fn run_touch(opts: &McConfig, cmd: &TouchCommand, client: &MemcachedClient
 
 async fn read_input() -> io::Result<Vec<u8>> {
     let mut buf = Vec::new();
-    let mut input = BufReader::new(tokio::io::stdin());
+    let mut input = BufReader::new(tokio::io::stdin()).take(Memcached::MAX_PAYLOAD_SIZE);
     input.read_to_end(&mut buf).await?;
     Ok(buf)
 }


### PR DESCRIPTION
Limit the amount of data read from stdin for storage (`set`, `add`, `replace`) commands to the max item size that Memcached will allow us to store.